### PR TITLE
Makefile update: fix for missing libdl after upgrading NVML

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -102,9 +102,9 @@ ifeq ($(USE_NVML),yes)
 	DEPENDENCY_TARGETS+= nvml
 	FINAL_CFLAGS+= -I../deps/nvml/src/include -DUSE_NVML
 ifeq ($(NVML_DEBUG),yes)
-	FINAL_LIBS+= ../deps/nvml/src/debug/libpmemobj.a ../deps/nvml/src/debug/libpmem.a
+	FINAL_LIBS+= ../deps/nvml/src/debug/libpmemobj.so ../deps/nvml/src/debug/libpmem.so
 else
-	FINAL_LIBS+= ../deps/nvml/src/nondebug/libpmemobj.a ../deps/nvml/src/nondebug/libpmem.a
+	FINAL_LIBS+= ../deps/nvml/src/nondebug/libpmemobj.so ../deps/nvml/src/nondebug/libpmem.so
 endif
 endif
 


### PR DESCRIPTION
With new NVML including -ldl lib was necessary to compile Redis with NVML. This commit changes linking to dynamic, so specifying libdl is not needed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/5)

<!-- Reviewable:end -->
