### PR TITLE
re-visit PMEM adaptation of redis

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -110,7 +110,7 @@ endif
 
 ifeq ($(USE_NVML),yes)
 	DEPENDENCY_TARGETS+= nvml
-	FINAL_CFLAGS+= -I../deps/nvml/src/include -DUSE_NVML
+	FINAL_CFLAGS+= -I../deps/nvml/src/include -I../deps/nvml/src/libpmemobj -I../deps/nvml/src/common -DUSE_NVML
 ifeq ($(NVML_DEBUG),yes)
 	FINAL_LIBS+= ../deps/nvml/src/debug/libpmemobj.so ../deps/nvml/src/debug/libpmem.so
 else
@@ -147,6 +147,10 @@ REDIS_BENCHMARK_OBJ=ae.o anet.o redis-benchmark.o adlist.o zmalloc.o redis-bench
 REDIS_CHECK_RDB_NAME=redis-check-rdb
 REDIS_CHECK_AOF_NAME=redis-check-aof
 REDIS_CHECK_AOF_OBJ=redis-check-aof.o
+
+ifeq ($(USE_NVML),yes)
+	REDIS_SERVER_OBJ+= pmem.o
+endif
 
 all: $(REDIS_SERVER_NAME) $(REDIS_SENTINEL_NAME) $(REDIS_CLI_NAME) $(REDIS_BENCHMARK_NAME) $(REDIS_CHECK_RDB_NAME) $(REDIS_CHECK_AOF_NAME)
 	@echo ""

--- a/src/debug.c
+++ b/src/debug.c
@@ -155,7 +155,7 @@ void computeDatasetDigest(unsigned char *final) {
             if (o->type == OBJ_STRING) {
                 mixObjectDigest(digest,o);
             } else if (o->type == OBJ_LIST) {
-                listTypeIterator *li = listTypeInitIterator(o,0,LIST_TAIL);
+                listTypeIterator *li = listTypeInitIterator(o,0,REDIS_LIST_TAIL);
                 listTypeEntry entry;
                 while(listTypeNext(li,&entry)) {
                     robj *eleobj = listTypeGet(&entry);

--- a/src/dict.h
+++ b/src/dict.h
@@ -55,20 +55,6 @@ typedef struct dictEntry {
     struct dictEntry *next;
 } dictEntry;
 
-typedef struct dictEntryPM {
-    void *key;
-    union {
-        void *val;
-        uint64_t u64;
-        int64_t s64;
-        double d;
-    } v;
-    struct dictEntry *next;
-    PMEMoid key_oid;
-    PMEMoid val_oid;
-    POBJ_LIST_ENTRY(struct dictEntryPM) pmem_list;
-} dictEntryPM;
-
 typedef struct dictType {
     unsigned int (*hashFunction)(const void *key);
     void *(*keyDup)(void *privdata, const void *key);
@@ -195,7 +181,7 @@ unsigned long dictScan(dict *d, unsigned long v, dictScanFunction *fn, void *pri
 /* PMEM-specific API */
 int dictAddPM(dict *d, void *key, void *val);
 dictEntry *dictAddRawPM(dict *d, void *key);
-dictEntry *dictAddReconstructedPM(dict *d, dictEntry *entry);
+dictEntry *dictAddReconstructedPM(dict *d, void *key, void *val);
 int dictReplacePM(dict *d, void *key, void *val);
 #endif
 

--- a/src/dict.h
+++ b/src/dict.h
@@ -55,6 +55,20 @@ typedef struct dictEntry {
     struct dictEntry *next;
 } dictEntry;
 
+typedef struct dictEntryPM {
+    void *key;
+    union {
+        void *val;
+        uint64_t u64;
+        int64_t s64;
+        double d;
+    } v;
+    struct dictEntry *next;
+    PMEMoid key_oid;
+    PMEMoid val_oid;
+    POBJ_LIST_ENTRY(struct dictEntryPM) pmem_list;
+} dictEntryPM;
+
 typedef struct dictType {
     unsigned int (*hashFunction)(const void *key);
     void *(*keyDup)(void *privdata, const void *key);
@@ -181,6 +195,7 @@ unsigned long dictScan(dict *d, unsigned long v, dictScanFunction *fn, void *pri
 /* PMEM-specific API */
 int dictAddPM(dict *d, void *key, void *val);
 dictEntry *dictAddRawPM(dict *d, void *key);
+dictEntry *dictAddReconstructedPM(dict *d, dictEntry *entry);
 int dictReplacePM(dict *d, void *key, void *val);
 #endif
 

--- a/src/pmem.c
+++ b/src/pmem.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2017, Andreas Bluemle <andreas dot bluemle at itxperts dot de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifdef USE_NVML
+#include "server.h"
+#include "obj.h"
+#include "libpmemobj.h"
+#include "list.h"
+#include "util.h"
+
+int
+pmemReconstruct(void)
+{
+    uint64_t i = 0;
+    TOID(struct redis_pmem_root) root;
+    TOID(struct dictEntryPM) entryPM_oid;
+    dict *d;
+    dictEntryPM *entryPM;
+    /* void *key; */
+    /* void *val; */
+    void *pmem_base_addr;
+    robjPM *objectPM;
+
+    root = POBJ_ROOT(server.pm_pool, struct redis_pmem_root);
+    pmem_base_addr = (void *)server.pm_pool->addr;
+    serverLog(LL_NOTICE,"pmemReconstruct: %ld entries, base_addr 0x%lx", D_RO(root)->num_dict_entries, (uint64_t)pmem_base_addr);
+    d = server.db[0].dict;
+    dictExpand(d, D_RO(root)->num_dict_entries);
+    POBJ_LIST_FOREACH(entryPM_oid, &D_RO(root)->head, pmem_list) {
+        i++;
+	/* entryPM = pmemobj_direct(entryPM_oid.oid); */
+	entryPM = (dictEntryPM *)(entryPM_oid.oid.off + (uint64_t)pmem_base_addr);
+	entryPM->key = (void *)(entryPM->key_oid.off + (uint64_t)pmem_base_addr);
+	entryPM->v.val = (void *)(entryPM->val_oid.off + (uint64_t)pmem_base_addr);
+        objectPM = entryPM->v.val;
+        /* serverLog(LL_NOTICE,"pmemReconstruct: dictEntry %ld, off 0x%ld @ 0x%lx, key 0x%lx, val object 0x%lx", i, entryPM_oid.oid.off, (uint64_t)entryPM, (uint64_t)entryPM->key, (uint64_t)entryPM->v.val); */
+        if (objectPM->type == OBJ_STRING) {
+            /* serverLog(LL_NOTICE,"pmemReconstruct: redis object type %d encoding %d", objectPM->type, objectPM->encoding); */
+            if (objectPM->encoding == OBJ_ENCODING_RAW || objectPM->encoding == OBJ_ENCODING_EMBSTR) {
+                if (objectPM->encoding == OBJ_ENCODING_RAW) {
+                    objectPM->ptr = (void *)(objectPM->ptr_oid.off + (uint64_t)pmem_base_addr);
+                } else if (objectPM->encoding == OBJ_ENCODING_EMBSTR) {
+                    struct sdshdr8 *sh;
+                    sh = (void *)(objectPM+1);
+                    objectPM->ptr = sh+1;
+                }
+                (void)dictAddReconstructedPM(d, (dictEntry *)entryPM);
+                /* serverLog(LL_NOTICE,"pmemReconstruct: redis object ptr 0x%lx", (uint64_t)objectPM->ptr); */
+            } else {
+                serverLog(LL_WARNING,"pmemReconstruct: unexpected redis object encoding %d", objectPM->encoding);
+            }
+        } else {
+            serverLog(LL_WARNING,"pmemReconstruct: unexpected redis object type %d", objectPM->type);
+        }
+    }
+    return C_OK;
+}
+
+#endif

--- a/src/pmem.h
+++ b/src/pmem.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2017, Andreas Bluemle <andreas dot bluemle at itxperts dot de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __PMEM_H
+#define __PMEM_H
+
+#ifdef USE_NVML
+int pmemReconstruct(void);
+#endif
+
+#endif

--- a/src/pmem.h
+++ b/src/pmem.h
@@ -31,7 +31,16 @@
 #define __PMEM_H
 
 #ifdef USE_NVML
+typedef struct key_val_pair_PM {
+    PMEMoid key_oid;
+    PMEMoid val_oid;
+    POBJ_LIST_ENTRY(struct key_val_pair_PM) pmem_list;
+} key_val_pair_PM;
+
 int pmemReconstruct(void);
+void pmemKVpairSet(void *key, void *val);
+PMEMoid pmemAddToPmemList(void *key, void *val);
+void pmemRemoveFromPmemList(PMEMoid kv_PM_oid);
 #endif
 
 #endif

--- a/src/sds.h
+++ b/src/sds.h
@@ -39,6 +39,10 @@
 #include <stdarg.h>
 #include <stdint.h>
 
+#ifdef USE_NVML
+#include "libpmemobj.h"
+#endif
+
 typedef char *sds;
 
 /* Note: sdshdr5 is never used, we just access the flags byte directly.
@@ -228,8 +232,9 @@ sds sdscpy(sds s, const char *t);
 
 #ifdef USE_NVML
 sds sdsnewlenPM(const void *init, size_t initlen);
-sds sdsdupPM(const sds s);
+sds sdsdupPM(const sds s, void **oid_reference);
 void sdsfreePM(sds s);
+PMEMoid *sdsPMEMoidBackReference(sds s);
 #endif
 
 sds sdscatvprintf(sds s, const char *fmt, va_list ap);

--- a/src/server.c
+++ b/src/server.c
@@ -1519,6 +1519,7 @@ void initServerConfig(void) {
 #ifdef USE_NVML
     server.pm_file_path = NULL;
     server.pm_file_size = CONFIG_DEFAULT_PM_FILE_SIZE;
+    server.pm_reconstruct_required = false;
 #endif
     server.supervised = 0;
     server.supervised_mode = SUPERVISED_NONE;
@@ -1959,9 +1960,15 @@ void initServer(void) {
     /* Create the Redis databases, and initialize other internal state. */
     for (j = 0; j < server.dbnum; j++) {
 #ifdef USE_NVML
-        if (server.persistent)
+        if (server.persistent) {
             server.db[j].dict = dictCreate(&dbDictTypePM,NULL);
-        else
+            
+            pm_type_root_type_id = TOID_TYPE_NUM(struct redis_pmem_root);
+            pm_type_dictentry_type_id = TOID_TYPE_NUM(struct dictEntryPM);
+            pm_type_object_type_id = TOID_TYPE_NUM(struct redisObjectPM);
+            pm_type_sds_type_id = TOID_TYPE_NUM(struct sdsPM);
+            pm_type_emb_sds_type_id = TOID_TYPE_NUM(struct sdsPM);
+        } else
 #endif
             server.db[j].dict = dictCreate(&dbDictType,NULL);
         server.db[j].expires = dictCreate(&keyptrDictType,NULL);
@@ -3989,6 +3996,9 @@ int redisIsSupervised(int mode) {
 #ifdef USE_NVML
 void initPersistentMemory(void) {
     PMEMoid oid;
+    TOID(struct redis_pmem_root) rootoid;
+    struct redis_pmem_root *root;
+    
 
     long long start = ustime();
     char pmfile_hmem[64];
@@ -4002,12 +4012,17 @@ void initPersistentMemory(void) {
     if (server.pm_pool == NULL) {
         /* Open the existing PMEM pool file. */
         server.pm_pool = pmemobj_open(server.pm_file_path, PM_LAYOUT_NAME);
+	server.pm_reconstruct_required = true;
 
         if (server.pm_pool == NULL) {
-            serverLog(LL_WARNING,"Cannot int persistent memory poolset file "
+            serverLog(LL_WARNING,"Cannot init persistent memory poolset file "
                 "%s size %s", server.pm_file_path, pmfile_hmem);
             exit(1);
         }
+    } else {
+        rootoid = POBJ_ROOT(server.pm_pool, struct redis_pmem_root);
+        root = pmemobj_direct(rootoid.oid);
+        root->num_dict_entries = 0;
     }
 
     /* Get pool UUID from root object's OID. */
@@ -4179,6 +4194,17 @@ int main(int argc, char **argv) {
         linuxMemoryWarnings();
     #endif
         loadDataFromDisk();
+#ifdef USE_NVML
+        if (server.pm_reconstruct_required) {
+            long long start = ustime();
+            if (pmemReconstruct() == C_OK) {
+                serverLog(LL_NOTICE,"DB loaded from PMEM: %.3f seconds",(float)(ustime()-start)/1000000);
+            } else if (errno != ENOENT) {
+                serverLog(LL_WARNING,"Fatal error loading the DB from PMEM: %s. Exiting.",strerror(errno));
+                exit(1);
+            }
+	}
+#endif
         if (server.cluster_enabled) {
             if (verifyClusterConfigWithData() == C_ERR) {
                 serverLog(LL_WARNING,

--- a/src/server.h
+++ b/src/server.h
@@ -48,6 +48,42 @@
 #include <lua.h>
 #include <signal.h>
 
+#ifdef USE_NVML
+#include "pmem.h"
+#include <sys/queue.h>
+#include "libpmemobj.h"
+
+uint64_t pm_type_root_type_id;
+uint64_t pm_type_dictentry_type_id;
+uint64_t pm_type_object_type_id;
+uint64_t pm_type_sds_type_id;
+uint64_t pm_type_emb_sds_type_id;
+
+/* Type Dictionary Entry */
+#define PM_TYPE_ENTRY pm_type_dictentry_type_id
+/* Type Redis Object */
+#define PM_TYPE_OBJECT pm_type_object_type_id
+/* Type SDS Object */
+#define PM_TYPE_SDS pm_type_sds_type_id
+/* Type Embedded SDS Object */
+#define PM_TYPE_EMB_SDS pm_type_emb_sds_type_id
+
+#define PM_LAYOUT_NAME "store_db"
+
+POBJ_LAYOUT_BEGIN(store_db);
+POBJ_LAYOUT_TOID(store_db, struct redis_pmem_root);
+POBJ_LAYOUT_TOID(store_db, struct dictEntryPM);
+POBJ_LAYOUT_TOID(store_db, struct redisObjectPM);
+POBJ_LAYOUT_TOID(store_db, struct sdsPM);
+POBJ_LAYOUT_END(store_db);
+
+struct redis_pmem_root {
+	uint64_t num_dict_entries;
+	POBJ_LIST_HEAD(dictEntries, struct dictEntryPM) head;
+};
+
+#endif
+
 typedef long long mstime_t; /* millisecond time type. */
 
 #include "ae.h"      /* Event driven programming library */
@@ -70,22 +106,6 @@ typedef long long mstime_t; /* millisecond time type. */
 #include "endianconv.h"
 #include "crc64.h"
 
-#ifdef USE_NVML
-
-#include "libpmemobj.h"
-
-/* Type Dictionary Entry */
-#define PM_TYPE_ENTRY 0
-/* Type Redis Object */
-#define PM_TYPE_OBJECT 1
-/* Type SDS Object */
-#define PM_TYPE_SDS 2
-/* Type Embedded SDS Object */
-#define PM_TYPE_EMB_SDS 3
-
-#define PM_LAYOUT_NAME "store_db"
-
-#endif
 
 /* Error codes */
 #define C_OK                    0
@@ -353,8 +373,8 @@ typedef long long mstime_t; /* millisecond time type. */
 #define CONFIG_REPL_SYNCIO_TIMEOUT 5
 
 /* List related stuff */
-#define LIST_HEAD 0
-#define LIST_TAIL 1
+#define REDIS_LIST_HEAD 0
+#define REDIS_LIST_TAIL 1
 
 /* Sort operations */
 #define SORT_OP_GET 0
@@ -489,6 +509,15 @@ typedef struct redisObject {
     int refcount;
     void *ptr;
 } robj;
+
+typedef struct redisObjectPM {
+    unsigned type:4;
+    unsigned encoding:4;
+    unsigned lru:LRU_BITS; /* lru time (relative to server.lruclock) */
+    int refcount;
+    void *ptr;
+    PMEMoid ptr_oid;
+} robjPM;
 
 /* Macro used to obtain the current LRU clock.
  * If the current resolution is lower than the frequency we refresh the
@@ -821,6 +850,7 @@ struct redisServer {
     char* pm_file_path;             /* Path to persistent memory file */
     size_t pm_file_size;            /* If PM file does not exist, create new one with given size */
     bool persistent;                /* Persistence enabled/disabled */
+    bool pm_reconstruct_required; /* reconstruct database form PMEM */
     PMEMobjpool *pm_pool;           /* PMEM pool handle */
     uint64_t pool_uuid_lo;          /* PMEM pool UUID */
 #endif

--- a/src/sort.c
+++ b/src/sort.c
@@ -355,7 +355,7 @@ void sortCommand(client *c) {
             listTypeEntry entry;
             li = listTypeInitIterator(sortval,
                     desc ? (long)(listTypeLength(sortval) - start - 1) : start,
-                    desc ? LIST_HEAD : LIST_TAIL);
+                    desc ? REDIS_LIST_HEAD : REDIS_LIST_TAIL);
 
             while(j < vectorlen && listTypeNext(li,&entry)) {
                 vector[j].obj = listTypeGet(&entry);
@@ -369,7 +369,7 @@ void sortCommand(client *c) {
             start = 0;
         }
     } else if (sortval->type == OBJ_LIST) {
-        listTypeIterator *li = listTypeInitIterator(sortval,0,LIST_TAIL);
+        listTypeIterator *li = listTypeInitIterator(sortval,0,REDIS_LIST_TAIL);
         listTypeEntry entry;
         while(listTypeNext(li,&entry)) {
             vector[j].obj = listTypeGet(&entry);
@@ -539,7 +539,7 @@ void sortCommand(client *c) {
             listIter li;
 
             if (!getop) {
-                listTypePush(sobj,vector[j].obj,LIST_TAIL);
+                listTypePush(sobj,vector[j].obj,REDIS_LIST_TAIL);
             } else {
                 listRewind(operations,&li);
                 while((ln = listNext(&li))) {
@@ -553,7 +553,7 @@ void sortCommand(client *c) {
                         /* listTypePush does an incrRefCount, so we should take care
                          * care of the incremented refcount caused by either
                          * lookupKeyByPattern or createStringObject("",0) */
-                        listTypePush(sobj,val,LIST_TAIL);
+                        listTypePush(sobj,val,REDIS_LIST_TAIL);
                         decrRefCount(val);
                     } else {
                         /* Always fails */


### PR DESCRIPTION
This pull request contains 2 commits: the first commit addresses the re-start of the redis server based on the data contained in PMEM. To enable this, the data structures stored in PMEM had to be extended by PMEMoid instead of simple virtual addresses; the data structures affected are dictEntry and redisObject.

The 2nd commit reduces the data stored in PMEM to only key-value pairs and does no longer store redis specific data structures like dictEntry or redisObject in PMEM. This enhances compatibility with existing redis code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/8)
<!-- Reviewable:end -->
