### PR TITLE
Changed config for tests

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -215,9 +215,9 @@ always-show-logo yes
 #
 #   save ""
 
-save 900 1
-save 300 10
-save 60 10000
+#save 900 1
+#save 300 10
+#save 60 10000
 
 # By default Redis will stop accepting writes if RDB snapshots are enabled
 # (at least one save point) and the latest background save failed.

--- a/tests/assets/default.conf
+++ b/tests/assets/default.conf
@@ -12,11 +12,8 @@ logfile ''
 databases 16
 latency-monitor-threshold 1
 
-save 900 1
-save 300 10
-save 60 10000
 
-rdbcompression yes
+rdbcompression no
 dbfilename dump.rdb
 dir ./
 


### PR DESCRIPTION
Disable RDB in tests and server configuration, we doesn't support this functionality and can cause problems further.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/33)
<!-- Reviewable:end -->
