### PR TITLE
Typo in preprocessor condition

### DIFF
--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -392,7 +392,7 @@ size_t zmalloc_get_memory_size(void) {
     mib[0] = CTL_HW;
 #if defined(HW_REALMEM)
     mib[1] = HW_REALMEM;        /* FreeBSD. ----------------- */
-#elif defined(HW_PYSMEM)
+#elif defined(HW_PHYSMEM)
     mib[1] = HW_PHYSMEM;        /* Others. ------------------ */
 #endif
     unsigned int size = 0;      /* 32-bit */


### PR DESCRIPTION
This PR fix typo in preprocessor condition from zmalloc.c

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/45)
<!-- Reviewable:end -->
