### PR TITLE
Remove unnecessary library from makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -125,7 +125,6 @@ ifeq ($(MALLOC),jemalloc)
 	FINAL_CFLAGS+= -I$(JEMALLOC_PATH)/jemalloc/obj/include
 	FINAL_CFLAGS+= -DJE_PREFIX=jemk_
 	FINAL_CFLAGS+= -I$(JEMALLOC_PATH)/include
-	FINAL_LIBS+= $(JEMALLOC_PATH)/jemalloc/obj/lib/libjemalloc.a
 	FINAL_LIBS+= -ldl
 	FINAL_LIBS+= -L$(JEMALLOC_PATH)/.libs -lmemkind
 endif


### PR DESCRIPTION
Remove redundant line from Makefile. Memkind library contains jemalloc symbols, so there is no need to link jemalloc lib with the same symbols.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/47)
<!-- Reviewable:end -->
