### PR TITLE
Unnecessary casting in malloc_wrapper

### DIFF
--- a/src/memkind_malloc.c
+++ b/src/memkind_malloc.c
@@ -20,16 +20,14 @@ static size_t used_memory = 0;
 
 void *memkind_alloc_wrapper(size_t size) {
     void *ptr = memkind_malloc(server.pmem_kind1, size);
-    if (ptr==NULL) return NULL;
-    update_memkind_malloc_stat_alloc(size);
-    return (char*)ptr;
+    if (ptr) update_memkind_malloc_stat_alloc(size);
+    return ptr;
 }
 
 void *memkind_calloc_wrapper(size_t size) {
     void *ptr = memkind_calloc(server.pmem_kind1, 1, size);
-    if (ptr==NULL) return NULL;
-    update_memkind_malloc_stat_alloc(size);
-    return (char*)ptr;
+    if (ptr) update_memkind_malloc_stat_alloc(size);
+    return ptr;
 }
 
 void *memkind_realloc_wrapper(void *ptr, size_t size) {
@@ -37,17 +35,16 @@ void *memkind_realloc_wrapper(void *ptr, size_t size) {
     if (ptr == NULL) return memkind_alloc_wrapper(size);
     oldsize = jemk_malloc_usable_size(ptr);
     void *newptr = memkind_realloc(server.pmem_kind1, ptr, size);
-    if (newptr==NULL) return NULL;
-
-    update_memkind_malloc_stat_free(oldsize);
-    update_memkind_malloc_stat_alloc(size);
-    return (char*)newptr;
+    if (newptr) {
+        update_memkind_malloc_stat_free(oldsize);
+        update_memkind_malloc_stat_alloc(size);
+    }
+    return newptr;
 }
 
 void memkind_free_wrapper(void *ptr) {
     if(!ptr) return;
-    size_t oldsize;
-    oldsize = jemk_malloc_usable_size(ptr);
+    size_t oldsize = jemk_malloc_usable_size(ptr);
     update_memkind_malloc_stat_free(oldsize);
     memkind_free(server.pmem_kind1, ptr);
 }


### PR DESCRIPTION
Delete unnecessary casting when returning new pointer from malloc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/53)
<!-- Reviewable:end -->
