### PR TITLE
Segmentation fault in case of missing configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,12 +105,13 @@ If you want to see a more verbose output use the following:
 Running Redis
 -------------
 
-To run Redis with the default configuration just type:
+To run Redis with the default configuration, you have to provide specific location
+for memkind allocations with given size using an additonal parameter (pmdir):
 
     % cd src
-    % ./redis-server
+    % ./redis-server --pmdir /path/to/pmdir size
 
-If you want to provide your redis.conf, you have to run it using an additional
+To run Redis you have to provide your configuration file and run it using an additional
 parameter (the path of the configuration file):
 
     % cd src
@@ -119,7 +120,7 @@ parameter (the path of the configuration file):
 It is possible to alter the Redis configuration by passing parameters directly
 as options using the command line. Examples:
 
-    % ./redis-server --port 9999 --slaveof 127.0.0.1 6379
+    % ./redis-server --port 9999 --slaveof 127.0.0.1 6379 --pmdir /mnt/pmem/ 1g
     % ./redis-server /etc/redis/6379.conf --loglevel debug
 
 All the options in redis.conf are also supported as options using the command

--- a/src/Makefile
+++ b/src/Makefile
@@ -25,6 +25,7 @@ WARN=-Wall -W -Wno-missing-field-initializers
 OPT=$(OPTIMIZATION)
 JEMALLOC_PATH=../deps/jemalloc_JE/
 MEMKIND_PATH=../deps/memkind
+TEST_PMEM_DIR_PATH=/mnt/pmem/
 PREFIX?=/usr/local
 INSTALL_BIN=$(PREFIX)/bin
 INSTALL=install
@@ -245,6 +246,9 @@ distclean: clean
 .PHONY: distclean
 
 test: $(REDIS_SERVER_NAME) $(REDIS_CHECK_AOF_NAME)
+ifeq ($(wildcard $(TEST_PMEM_DIR_PATH)),)
+	$(error pmem directory used in test: $(TEST_PMEM_DIR_PATH) does not exist)
+endif
 	@(cd ..; ./runtest --conf tests/test.conf)
 
 test-sentinel: $(REDIS_SENTINEL_NAME)

--- a/src/server.c
+++ b/src/server.c
@@ -3455,10 +3455,10 @@ void usage(void) {
     fprintf(stderr,"       ./redis-server -h or --help\n");
     fprintf(stderr,"       ./redis-server --test-memory <megabytes>\n\n");
     fprintf(stderr,"Examples:\n");
-    fprintf(stderr,"       ./redis-server (run the server with default conf)\n");
+    fprintf(stderr,"       ./redis-server --pmdir /mnt/pmem/ 1g (run the server with default conf)\n");
     fprintf(stderr,"       ./redis-server /etc/redis/6379.conf\n");
-    fprintf(stderr,"       ./redis-server --port 7777\n");
-    fprintf(stderr,"       ./redis-server --port 7777 --slaveof 127.0.0.1 8888\n");
+    fprintf(stderr,"       ./redis-server --port 7777 --pmdir /mnt/pmem/ 1g\n");
+    fprintf(stderr,"       ./redis-server --port 7777 --slaveof 127.0.0.1 8888 --pmdir /mnt/pmem/ 1g\n");
     fprintf(stderr,"       ./redis-server /etc/myredis.conf --loglevel verbose\n\n");
     fprintf(stderr,"Sentinel mode:\n");
     fprintf(stderr,"       ./redis-server /etc/sentinel.conf --sentinel\n");
@@ -3875,13 +3875,20 @@ int main(int argc, char **argv) {
     int background = server.daemonize && !server.supervised;
     if (background) daemonize();
 
-    err = memkind_create_pmem(server.pm_dir_path, server.pm_file_size, &server.pmem_kind1);
-	if (err) {
-		perror("memkind_create_pmem()");
-		fprintf(stderr, "Unable to create pmem partition\n");
-	} else {
-		printf("memkind created\n");
-	}
+    if (server.pm_dir_path) {
+        err = memkind_create_pmem(server.pm_dir_path, server.pm_file_size, &server.pmem_kind1);
+        if (err) {
+            perror("memkind_create_pmem()");
+            fprintf(stderr, "Unable to create pmem partition\n");
+            exit(1);
+        } else {
+            printf("memkind created\n");
+        }
+    } else {
+        fprintf(stderr,"Please specify the location for memkind allocations with given size.\n");
+        fprintf(stderr,"Example: ./redis-server --pmdir /mnt/pmem/ 1g\n\n");
+        exit(1);
+    }
 
     initServer();
     if (background || server.pidfile) createPidFile();


### PR DESCRIPTION
Steps to reproduce:
build project:
**% ./make all**
execute command redis-server without configuration file:
**% cd src
% ./redis-server**
Warning: no config file specified, using the default config. In order to specify a config file use ./redis-server /path/to/redis.conf
**Segmentation fault (core dumped)**

Main reason of this is:
https://github.com/pmem/redis/blob/fedea7ba480af1e1ec1088c88cf5ceccfd409ae9/src/server.c#L3865

**server.pm_dir_path** is set to NULL in **initServerConfig** function - it wasn't modified because no configuration file was loaded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/58)
<!-- Reviewable:end -->
