### PR TITLE
Fix overwriting keys_on_pm config variable on startup

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1851,7 +1851,6 @@ void initServer(void) {
     server.get_ack_from_slaves = 0;
     server.clients_paused = 0;
     server.system_memory_size = zmalloc_get_memory_size();
-    server.keys_on_pm = false;
 
     createSharedObjects();
     adjustOpenFilesLimit();


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/68)
<!-- Reviewable:end -->
