### PR TITLE
Geo fix - allocator mismatch

### DIFF
--- a/src/geo.c
+++ b/src/geo.c
@@ -445,7 +445,7 @@ void geoaddCommand(client *c) {
 
     /* Finally call ZADD that will do the work for us. */
     replaceClientCommandVector(c,argc,argv);
-    zaddCommand(c);
+    zaddCommandZ(c);
 }
 
 #define SORT_NONE 0

--- a/src/server.h
+++ b/src/server.h
@@ -2016,6 +2016,7 @@ void debugCommand(client *c);
 void msetCommand(client *c);
 void msetnxCommand(client *c);
 void zaddCommand(client *c);
+void zaddCommandZ(client *c);
 void zincrbyCommand(client *c);
 void zrangeCommand(client *c);
 void zrangebyscoreCommand(client *c);

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1483,7 +1483,7 @@ long zsetRank(robj *zobj, sds ele, int reverse) {
  *----------------------------------------------------------------------------*/
 
 /* This generic command implements both ZADD and ZINCRBY. */
-void zaddGenericCommand(client *c, int flags) {
+void zaddGenericCommand(client *c, int flags, alloc a) {
     static char *nanerr = "resulting score is not a number (NaN)";
     robj *key = c->argv[1];
     robj *zobj;
@@ -1556,9 +1556,9 @@ void zaddGenericCommand(client *c, int flags) {
         if (server.zset_max_ziplist_entries == 0 ||
             server.zset_max_ziplist_value < sdslen(c->argv[scoreidx+1]->ptr))
         {
-            zobj = createZsetObjectM();
+            zobj = createZsetObjectA(a);
         } else {
-            zobj = createZsetZiplistObjectM();
+            zobj = createZsetZiplistObjectA(a);
         }
         dbAdd(c->db,key,zobj);
     } else {
@@ -1574,7 +1574,7 @@ void zaddGenericCommand(client *c, int flags) {
         int retflags = flags;
 
         ele = c->argv[scoreidx+1+j*2]->ptr;
-        int retval = zsetAddM(zobj, score, ele, &retflags, &newscore);
+        int retval = zsetAddA(zobj, score, ele, &retflags, &newscore, a);
         if (retval == 0) {
             addReplyError(c,nanerr);
             goto cleanup;
@@ -1606,11 +1606,15 @@ cleanup:
 }
 
 void zaddCommand(client *c) {
-    zaddGenericCommand(c,ZADD_NONE);
+    zaddGenericCommand(c,ZADD_NONE,m_alloc);
+}
+
+void zaddCommandZ(client *c) {
+    zaddGenericCommand(c,ZADD_NONE,z_alloc);
 }
 
 void zincrbyCommand(client *c) {
-    zaddGenericCommand(c,ZADD_INCR);
+    zaddGenericCommand(c,ZADD_INCR,m_alloc);
 }
 
 void zremCommand(client *c) {


### PR DESCRIPTION
 found bug which cause stuck on geo tests. Geo should be stored in RAM, so I modified code to avoid creating objects by Memkind allocator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/73)
<!-- Reviewable:end -->
