### PR TITLE
Modifies memcpy and memset functions for PM data

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -126,7 +126,7 @@ ifeq ($(MALLOC),jemalloc)
 	FINAL_CFLAGS+= -DUSE_JEMALLOC -I$(JEMALLOC_PATH)/include
 	FINAL_CFLAGS+= -DJE_PREFIX=je_
 	FINAL_CFLAGS+= -I$(MEMKIND_PATH)/include
-	FINAL_LIBS+= -ldl
+	FINAL_LIBS+= -ldl -lpmem
 	FINAL_LIBS+= $(JEMALLOC_PATH)/lib/libjemalloc.a
 endif
 

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -36,7 +36,9 @@ int allocCompare(alloc lhs, alloc rhs) {
             lhs->alloc_size == rhs->alloc_size &&
             lhs->alloc_no_tcache == rhs->alloc_no_tcache &&
             lhs->free_no_tcache == rhs->free_no_tcache &&
-            lhs->get_defrag_hint == rhs->get_defrag_hint) {
+            lhs->get_defrag_hint == rhs->get_defrag_hint &&
+            lhs->memcpy == rhs->memcpy &&
+            lhs->memset == rhs->memset) {
         return 0;
     }
     return -1;

--- a/src/alloc.h
+++ b/src/alloc.h
@@ -51,6 +51,8 @@ struct __alloc {
     void *(*alloc_no_tcache)(size_t size);
     void (*free_no_tcache)(void *ptr);
     int (*get_defrag_hint)(void* ptr, int *bin_util, int *run_util);
+    void *(*memcpy)(void* dst, const void * src, size_t num);
+    void *(*memset)( void* ptr, int value, size_t num);
 };
 typedef const struct __alloc *alloc;
 
@@ -62,7 +64,9 @@ static const struct __alloc __z_alloc = {
     je_malloc_usable_size, /*zmalloc_size,*/
     zmalloc_no_tcache,
     zfree_no_tcache,
-    je_get_defrag_hint
+    je_get_defrag_hint,
+    zmemcpy,
+    zmemset
 };
 static const struct __alloc *z_alloc = &__z_alloc;
 
@@ -74,7 +78,9 @@ static const struct __alloc __m_alloc = {
     mmalloc_usable_size,
     mmalloc,
     mfree_no_tcache,
-    mget_defrag_hint
+    mget_defrag_hint,
+    mmemcpy,
+    mmemset
 };
 static const struct __alloc *m_alloc = &__m_alloc;
 

--- a/src/memkind_malloc.c
+++ b/src/memkind_malloc.c
@@ -2,6 +2,8 @@
 #include "atomicvar.h"
 
 #include <memkind.h>
+#include <libpmem.h>
+
 
 #define update_memkind_malloc_stat_alloc(__n) do { \
     size_t _n = (__n); \
@@ -67,4 +69,11 @@ size_t memkind_malloc_used_memory(void){
     size_t um;
     atomicGet(used_memory,um);
     return um;
+}
+
+void *pmem_memcpy_wrapper(void *pmemdest, const void *src, size_t len){
+    return pmem_memcpy(pmemdest, src, len ,PMEM_F_MEM_NONTEMPORAL|PMEM_F_MEM_NODRAIN);
+}
+void *pmem_memset_wrapper(void *pmemdest, int c, size_t len){
+    return pmem_memset(pmemdest, c, len ,PMEM_F_MEM_NONTEMPORAL|PMEM_F_MEM_NODRAIN);
 }

--- a/src/memkind_malloc.c
+++ b/src/memkind_malloc.c
@@ -1,9 +1,8 @@
 #include "server.h"
 #include "atomicvar.h"
 
-#include <memkind.h>
 #include <libpmem.h>
-
+#include <memkind.h>
 
 #define update_memkind_malloc_stat_alloc(__n) do { \
     size_t _n = (__n); \
@@ -72,8 +71,10 @@ size_t memkind_malloc_used_memory(void){
 }
 
 void *pmem_memcpy_wrapper(void *pmemdest, const void *src, size_t len){
-    return pmem_memcpy(pmemdest, src, len ,PMEM_F_MEM_NONTEMPORAL|PMEM_F_MEM_NODRAIN);
+    return pmem_memcpy(pmemdest, src, len, PMEM_F_MEM_NONTEMPORAL|PMEM_F_MEM_NODRAIN);
 }
+
 void *pmem_memset_wrapper(void *pmemdest, int c, size_t len){
-    return pmem_memset(pmemdest, c, len ,PMEM_F_MEM_NONTEMPORAL|PMEM_F_MEM_NODRAIN);
+    return pmem_memset(pmemdest, c, len, PMEM_F_MEM_NONTEMPORAL|PMEM_F_MEM_NODRAIN);
 }
+

--- a/src/memkind_malloc.h
+++ b/src/memkind_malloc.h
@@ -9,6 +9,8 @@ void *memkind_realloc_wrapper(void *ptr, size_t size);
 void memkind_free_wrapper(void *ptr);
 void memkind_free_no_tcache_wrapper(void *ptr);
 size_t memkind_malloc_used_memory(void);
+void *pmem_memcpy_wrapper(void *pmemdest, const void *src, size_t len);
+void *pmem_memset_wrapper(void *pmemdest, int c, size_t len);
 
 #define mmalloc memkind_alloc_wrapper
 #define mcalloc memkind_calloc_wrapper
@@ -17,3 +19,5 @@ size_t memkind_malloc_used_memory(void);
 #define mmalloc_usable_size jemk_malloc_usable_size
 #define mget_defrag_hint jemk_get_defrag_hint
 #define mfree_no_tcache memkind_free_no_tcache_wrapper
+#define mmemcpy pmem_memcpy_wrapper
+#define mmemset pmem_memset_wrapper

--- a/src/sds.c
+++ b/src/sds.c
@@ -92,7 +92,7 @@ sds sdsnewlenA(const void *init, size_t initlen, alloc a) {
 
     sh = a->alloc(hdrlen+initlen+1);
     if (!init)
-        memset(sh, 0, hdrlen+initlen+1);
+        a->memset(sh, 0, hdrlen+initlen+1);
     if (sh == NULL) return NULL;
     s = (char*)sh+hdrlen;
     fp = ((unsigned char*)s)-1;
@@ -131,7 +131,7 @@ sds sdsnewlenA(const void *init, size_t initlen, alloc a) {
         }
     }
     if (initlen && init)
-        memcpy(s, init, initlen);
+        a->memcpy(s, init, initlen);
     s[initlen] = '\0';
     return s;
 }

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -214,9 +214,11 @@ size_t zmalloc_used_memory(void) {
     atomicGet(used_memory,um);
     return um;
 }
+
 void *zmemcpy(void* dst, const void* src, size_t num){
     return memcpy(dst, src, num);
 }
+
 void *zmemset(void* dst, int value, size_t num){
     return memset(dst, value, num);
 }

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -214,6 +214,12 @@ size_t zmalloc_used_memory(void) {
     atomicGet(used_memory,um);
     return um;
 }
+void *zmemcpy(void* dst, const void* src, size_t num){
+    return memcpy(dst, src, num);
+}
+void *zmemset(void* dst, int value, size_t num){
+    return memset(dst, value, num);
+}
 
 void zmalloc_set_oom_handler(void (*oom_handler)(size_t)) {
     zmalloc_oom_handler = oom_handler;

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -85,6 +85,8 @@ size_t zmalloc_get_private_dirty(long pid);
 size_t zmalloc_get_smap_bytes_by_field(char *field, long pid);
 size_t zmalloc_get_memory_size(void);
 void zlibc_free(void *ptr);
+void *zmemcpy(void* dst, const void* src, size_t num);
+void *zmemset(void* ptr, int value, size_t num);
 
 #ifdef HAVE_DEFRAG
 void zfree_no_tcache(void *ptr);


### PR DESCRIPTION
For PM allocated strings uses pmem_memcpy and pmem_memset from PMDK
library - libpmem. Performance increases for multi-instance scenarios.
This commit partially modifies only sds behaviour.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/75)
<!-- Reviewable:end -->
