### PR TITLE
On startup keys and string values goes from rdb file to pmem

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1164,7 +1164,7 @@ robj *rdbLoadCheckModuleValue(rio *rdb, char *modulename) {
 
 /* Load a Redis object of the specified type from the specified file.
  * On success a newly allocated object is returned, otherwise NULL. */
-robj *rdbLoadObject(int rdbtype, rio *rdb) {
+robj *rdbLoadObjectA(int rdbtype, rio *rdb, alloc a) {
     robj *o = NULL, *ele, *dec;
     uint64_t len;
     unsigned int i;
@@ -1172,7 +1172,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb) {
     if (rdbtype == RDB_TYPE_STRING) {
         /* Read string value */
         if ((o = rdbLoadEncodedStringObject(rdb)) == NULL) return NULL;
-        o = tryObjectEncoding(o);
+        o = tryObjectEncodingA(o, a);
     } else if (rdbtype == RDB_TYPE_LIST) {
         /* Read list value */
         if ((len = rdbLoadLen(rdb,NULL)) == RDB_LENERR) return NULL;
@@ -1629,7 +1629,7 @@ int rdbLoadRio(rio *rdb, rdbSaveInfo *rsi) {
         /* Read key */
         if ((key = rdbLoadStringObject(rdb)) == NULL) goto eoferr;
         /* Read value */
-        if ((val = rdbLoadObject(type,rdb)) == NULL) goto eoferr;
+        if ((val = rdbLoadObjectM(type,rdb)) == NULL) goto eoferr;
         /* Check if the key already expired. This function is used when loading
          * an RDB file from disk, either at startup, or when an RDB was
          * received from the master. In the latter case, the master is

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -135,7 +135,9 @@ void rdbRemoveTempFile(pid_t childpid);
 int rdbSave(char *filename, rdbSaveInfo *rsi);
 ssize_t rdbSaveObject(rio *rdb, robj *o);
 size_t rdbSavedObjectLen(robj *o);
-robj *rdbLoadObject(int type, rio *rdb);
+robj *rdbLoadObjectA(int type, rio *rdb, alloc a);
+static inline robj *rdbLoadObject(int type, rio *rdb) { return rdbLoadObjectA(type,rdb,z_alloc); }
+static inline robj *rdbLoadObjectM(int type, rio *rdb) { return rdbLoadObjectA(type,rdb,m_alloc); }
 void backgroundSaveDoneHandler(int exitcode, int bysignal);
 int rdbSaveKeyValuePair(rio *rdb, robj *key, robj *val, long long expiretime, long long now);
 robj *rdbLoadStringObject(rio *rdb);

--- a/src/server.c
+++ b/src/server.c
@@ -1483,7 +1483,7 @@ void initServerConfig(void) {
 
     server.pm_dir_path = NULL;
     server.pm_file_size = 1024 * 1024 * 16;
-    server.use_volatile = true;
+    server.use_volatile = false;
     server.keys_on_pm = true;
 
     unsigned int lruclock = getLRUClock();


### PR DESCRIPTION
rest of data types are allocated from rdb to dram and from client to pmem

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/83)
<!-- Reviewable:end -->
