### PR TITLE
Fix issue with child while RDB save

### DIFF
--- a/src/adlist.c
+++ b/src/adlist.c
@@ -52,6 +52,16 @@ list *listCreate(void)
     return list;
 }
 
+listM *listCreateM(void)
+{
+	struct listM *list;
+
+	if ((list = zmalloc(sizeof(*list))) == NULL)
+		return NULL;
+	list->head = NULL;
+	return list;
+}
+
 /* Remove all the elements from the list without destroying the list itself. */
 void listEmpty(list *list)
 {
@@ -103,6 +113,24 @@ list *listAddNodeHead(list *list, void *value)
     }
     list->len++;
     return list;
+}
+
+listM *listAddNodeHeadM(listM *list, void *value)
+{
+	listNodeM *node;
+
+	if ((node = zmalloc(sizeof(*node))) == NULL)
+		return NULL;
+	node->value = value;
+	if (list->head == NULL) {
+		list->head = node;
+		node->next = NULL;
+	}
+	else {
+		node->next = list->head;
+		list->head = node;
+	}
+	return list;
 }
 
 /* Add a new node to the list, to tail, containing the specified 'value'

--- a/src/adlist.h
+++ b/src/adlist.h
@@ -39,6 +39,11 @@ typedef struct listNode {
     void *value;
 } listNode;
 
+typedef struct listNodeM {
+	struct listNodeM *next;
+	void *value;
+} listNodeM;
+
 typedef struct listIter {
     listNode *next;
     int direction;
@@ -52,6 +57,10 @@ typedef struct list {
     int (*match)(void *ptr, void *key);
     unsigned long len;
 } list;
+
+typedef struct listM {
+	listNodeM *head;
+} listM;
 
 /* Functions implemented as macros */
 #define listLength(l) ((l)->len)
@@ -71,9 +80,11 @@ typedef struct list {
 
 /* Prototypes */
 list *listCreate(void);
+listM *listCreateM(void);
 void listRelease(list *list);
 void listEmpty(list *list);
 list *listAddNodeHead(list *list, void *value);
+listM *listAddNodeHeadM(listM *list, void *value);
 list *listAddNodeTail(list *list, void *value);
 list *listInsertNode(list *list, listNode *old_node, void *value, int after);
 void listDelNode(list *list, listNode *node);

--- a/src/config.c
+++ b/src/config.c
@@ -754,10 +754,10 @@ void loadServerConfigFromString(char *config) {
         sdsfreesplitres(argv,argc);
     }
     /* Disabling AOF and RDB */
-	if (server.use_volatile) {
-		server.aof_state = AOF_OFF;
-		resetServerSaveParams();
-    }
+	//if (server.use_volatile) {
+	//	server.aof_state = AOF_OFF;
+	//	resetServerSaveParams();
+ //   }
     /* Sanity checks. */
     if (server.cluster_enabled && server.masterhost) {
         linenum = slaveof_linenum;

--- a/src/server.c
+++ b/src/server.c
@@ -3957,6 +3957,8 @@ int main(int argc, char **argv) {
         serverLog(LL_WARNING,"WARNING: You specified a maxmemory value that is less than 1MB (current value is %llu bytes). Are you sure this is what you really want?", server.maxmemory);
     }
 
+	forkActive = 0;
+
     aeSetBeforeSleepProc(server.el,beforeSleep);
     aeSetAfterSleepProc(server.el,afterSleep);
     aeMain(server.el);

--- a/src/server.h
+++ b/src/server.h
@@ -1344,6 +1344,8 @@ uint64_t crc64(uint64_t crc, const unsigned char *s, uint64_t l);
 void exitFromChild(int retcode);
 size_t redisPopcount(void *s, long count);
 void redisSetProcTitle(char *title);
+void addToList(robj* old);
+void listEmptyM(listM *list);
 
 /* networking.c -- Networking and Client related operations */
 client *createClient(int fd);
@@ -1471,6 +1473,7 @@ void execCommandPropagateMulti(client *c);
 void decrRefCount(robj *o);
 void decrRefCountVoid(void *o);
 void incrRefCount(robj *o);
+void freeRobj(robj* o);
 robj *makeObjectShared(robj *o);
 robj *resetRefCount(robj *obj);
 void freeStringObject(robj *o);
@@ -1856,6 +1859,10 @@ int dbAsyncDelete(redisDb *db, robj *key);
 void emptyDbAsync(redisDb *db);
 void slotToKeyFlushAsync(void);
 size_t lazyfreeGetPendingObjectsCount(void);
+
+listM* robjUpdateValList;
+_Bool isListMinitialised;
+_Bool forkActive;
 
 /* API to get key arguments from commands */
 int *getKeysFromCommand(struct redisCommand *cmd, robj **argv, int argc, int *numkeys);


### PR DESCRIPTION
Fixes the issue where fork's child process (while doing RDB save) access memory freed by parent. Works only for raw and embedded string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/96)
<!-- Reviewable:end -->
