### PR TITLE
Dockerfile for fedora 29

### DIFF
--- a/utils/docker/Dockerfile.fedora-29
+++ b/utils/docker/Dockerfile.fedora-29
@@ -1,0 +1,61 @@
+#
+#  Copyright (C) 2019 Intel Corporation.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright notice(s),
+#     this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright notice(s),
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) ``AS IS'' AND ANY EXPRESS
+#  OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO
+#  EVENT SHALL THE COPYRIGHT HOLDER(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+#  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+#  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+#  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Pull base image
+FROM fedora:29
+
+LABEL maintainer="katarzyna.wasiuta@intel.com"
+
+# Update the dnf cache and install basic tools
+RUN dnf update -y && dnf install -y \
+    autoconf \
+    automake \
+    gcc \
+    libtool \
+    make \
+    numactl-devel \
+    && dnf clean all 
+
+# Install memkind
+# TODO: Change url to fedora-29 rpm after memkind official release
+ENV MEMKIND_URL="https://github.com/memkind/memkind/tarball/master"
+RUN mkdir -p memkind && \
+    cd memkind && \
+    curl -L $MEMKIND_URL | tar xz --strip-components=1 -C . && \
+    ./build_jemalloc.sh && \
+    ./autogen.sh && \
+    ./configure --prefix=/usr && \
+    make -j "$(nproc --all)" && \
+    make install && \
+    cd .. && \
+    rm -r memkind
+
+# Install redis from copy-on-write poc branch
+# TODO: Change url to 5.0-poc_cow tag
+ENV REDIS_URL="https://github.com/pmem/redis/archive/5.0-poc_cow.tar.gz"
+ENV REDIS_SRC="/usr/src/redis"
+RUN mkdir -p $REDIS_SRC && \
+    curl -L $REDIS_URL | tar xz --strip-components=1 -C $REDIS_SRC && \
+    make -C $REDIS_SRC MALLOC=memkind && \
+    make -C $REDIS_SRC install && \
+    rm -r $REDIS_SRC

--- a/utils/docker/README.md
+++ b/utils/docker/README.md
@@ -1,0 +1,16 @@
+# **README**
+
+This is utils/docker/README.
+
+Dockerfile.fedora-29 is responsible for building a Docker container
+with Fedora 29 environment and Redis installed
+
+
+# Building the container
+
+```
+$ docker build . -f Dockerfile.fedora-29 -t redis-$REDIS_VERSION-fedora-29 \
+ --build-arg http_proxy=$http_proxy \
+ --build-arg https_proxy=$https_proxy
+```
+


### PR DESCRIPTION
Add Dockerfile based on Fedora 29 that builds Redis, using memkind allocator
and installs it in the system

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/105)
<!-- Reviewable:end -->
