### PR TITLE
Fix minor memkind integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ To compile against jemalloc on Mac OS X systems, use:
 
     % make MALLOC=jemalloc
 
-To compile against memkind malloc, use:
+To compile against memkind, use:
 
     % make MALLOC=memkind
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -151,7 +151,7 @@ endif
 
 ifeq ($(MALLOC),memkind)
 	FINAL_CFLAGS+= -DUSE_MEMKIND
-	FINAL_LIBS+= -lnuma -lmemkind
+	FINAL_LIBS+= -lmemkind
 endif
 
 REDIS_CC=$(QUIET_CC)$(CC) $(FINAL_CFLAGS)

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -56,7 +56,7 @@
 #endif
 
 #elif defined(USE_MEMKIND)
-#define ZMALLOC_LIB ("jemalloc-" __xstr(JEMALLOC_VERSION_MAJOR) "." __xstr(JEMALLOC_VERSION_MINOR) "." __xstr(JEMALLOC_VERSION_BUGFIX))
+#define ZMALLOC_LIB "memkind"
 #include <memkind.h>
 #define HAVE_MALLOC_SIZE 1
 #define zmalloc_size(p) memkind_malloc_usable_size(NULL,p)


### PR DESCRIPTION
Update reference to memkind library in README 

Fix name in ZMALLOC_LIB to "memkind" 

Remove lnuma dependency - user could use here memkind without this package.

@jschmieg @kasiawasiuta I kindly please for review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/106)
<!-- Reviewable:end -->
