### PR TITLE
Fix preprocessor directive to USE_MEMKIND

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -514,8 +514,8 @@ robj *tryObjectEncoding(robj *o) {
     {
         o->ptr = sdsRemoveFreeSpace(o->ptr);
     }
-#ifdef USE_MEMKING
-    // move string type content to PMEM
+#ifdef USE_MEMKIND
+    /* Move string type content to PMEM */
     o->ptr = sdstoPM(o->ptr);
 #endif
     /* Return the original object. */


### PR DESCRIPTION
This PR fixes typo in preprocessor directive from USE_MEMKING -> USE_MEMKIND.

Fixes #114

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/115)
<!-- Reviewable:end -->
