### PR TITLE
Updated Fedora29 Dockerfile to link Redis with Memkind-1.9

### DIFF
--- a/utils/docker/Dockerfile.fedora-29
+++ b/utils/docker/Dockerfile.fedora-29
@@ -28,27 +28,15 @@ LABEL maintainer="katarzyna.wasiuta@intel.com"
 
 # Update the dnf cache and install basic tools
 RUN dnf update -y && dnf install -y \
-    autoconf \
-    automake \
     gcc \
-    libtool \
     make \
     numactl-devel \
     && dnf clean all 
 
-# Install memkind
-# TODO: Change url to fedora-29 rpm after memkind official release
-ENV MEMKIND_URL="https://github.com/memkind/memkind/tarball/master"
-RUN mkdir -p memkind && \
-    cd memkind && \
-    curl -L $MEMKIND_URL | tar xz --strip-components=1 -C . && \
-    ./build_jemalloc.sh && \
-    ./autogen.sh && \
-    ./configure --prefix=/usr && \
-    make -j "$(nproc --all)" && \
-    make install && \
-    cd .. && \
-    rm -r memkind
+# Install memkind and memkind-devel
+ENV MEMKIND_URL="http://download.opensuse.org/repositories/home:/mbiesek/Fedora_29/x86_64/memkind-1.9.0-2.1.x86_64.rpm"
+ENV MEMKIND_DEVEL_URL="http://download.opensuse.org/repositories/home:/mbiesek/Fedora_29/x86_64/memkind-devel-1.9.0-2.1.x86_64.rpm"
+RUN rpm -i $MEMKIND_URL && rpm -i $MEMKIND_DEVEL_URL 
 
 # Install redis from copy-on-write poc branch
 # TODO: Change url to 5.0-poc_cow tag


### PR DESCRIPTION
Simplified memkind installation in the system, using memkind 1.9 release rpm packages.
Removed unnecessary build packages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/116)
<!-- Reviewable:end -->
