### PR TITLE
Add support for pmem in Redis configuration

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1700,3 +1700,7 @@ rdb-save-incremental-fsync yes
 # Maximum number of set/hash/zset/list fields that will be processed from
 # the main dictionary scan
 # active-defrag-max-scan-fields 1000
+
+############################### PMEM CONFIG ###############################
+# Persistent memory allocation strategy for strings and embedded strings
+# pmem-str-mode none

--- a/src/config.c
+++ b/src/config.c
@@ -98,6 +98,23 @@ configEnum repl_diskless_load_enum[] = {
     {NULL, 0}
 };
 
+configEnum pmem_str_mode_enum[] = {
+    {"none", PMEM_NONE},
+    {"str-val", PMEM_STR_VAL},
+    {"str-val-robj", PMEM_STR_VAL_ROBJ},
+    {"str-val-key", PMEM_STR_VAL_KEY},
+    {"str-val-dictentry", PMEM_STR_VAL_DICTENTRY},
+    {"str-val-robj-key", PMEM_STR_VAL_ROBJ_KEY},
+    {"str-val-robj-dictentry", PMEM_STR_VAL_ROBJ_DICTENTRY},
+    {"str-val-key-dictentry", PMEM_STR_VAL_KEY_DICTENTRY},
+    {"str-all", PMEM_STR_ALL},
+    {"embstr-robjval", PMEM_EMBSTR_ROBJVAL},
+    {"embstr-robjval-key", PMEM_EMBSTR_ROBJVAL_KEY},
+    {"embstr-robjval-dictentry", PMEM_EMBSTR_ROBJVAL_DICTENTRY},
+    {"embstr-all", PMEM_EMBSTR_ALL},
+    {NULL, 0}
+};
+
 /* Output buffer limits presets. */
 clientBufferLimitsConfig clientBufferLimitsDefaults[CLIENT_TYPE_OBUF_COUNT] = {
     {0, 0, 0}, /* normal */
@@ -2192,6 +2209,7 @@ standardConfig configs[] = {
     createEnumConfig("loglevel", NULL, MODIFIABLE_CONFIG, loglevel_enum, server.verbosity, LL_NOTICE, NULL, NULL),
     createEnumConfig("maxmemory-policy", NULL, MODIFIABLE_CONFIG, maxmemory_policy_enum, server.maxmemory_policy, MAXMEMORY_NO_EVICTION, NULL, NULL),
     createEnumConfig("appendfsync", NULL, MODIFIABLE_CONFIG, aof_fsync_enum, server.aof_fsync, AOF_FSYNC_EVERYSEC, NULL, NULL),
+    createEnumConfig("pmem-str-mode", NULL, MODIFIABLE_CONFIG, pmem_str_mode_enum, server.pmem_str_mode, PMEM_NONE, NULL, NULL),
 
     /* Integer configs */
     createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.dbnum, 16, INTEGER_CONFIG, NULL, NULL),

--- a/src/server.h
+++ b/src/server.h
@@ -343,6 +343,38 @@ typedef long long ustime_t; /* microsecond time type. */
 #define AOF_FSYNC_ALWAYS 1
 #define AOF_FSYNC_EVERYSEC 2
 
+/* PMEM option */
+#define PMEM_NONE 0 /* PMEM: disabled */
+/* PMEM string option */
+#define PMEM_STR_VAL (1<<0) /* String: value on PMEM */
+#define PMEM_STR_ROBJ (1<<1) /* String: robj on PMEM */
+#define PMEM_STR_KEY (1<<2) /* String: key on PMEM */
+#define PMEM_STR_DICTENTRY (1<<3) /* String: dictentry on PMEM */
+#define PMEM_STR_VAL_ROBJ \
+     (PMEM_STR_VAL | PMEM_STR_ROBJ) /* String: value and robj on PMEM */
+#define PMEM_STR_VAL_KEY \
+     (PMEM_STR_VAL | PMEM_STR_KEY) /* String: value and key on PMEM */
+#define PMEM_STR_VAL_DICTENTRY \
+     (PMEM_STR_VAL | PMEM_STR_DICTENTRY) /* String: value and dictentry on PMEM */
+#define PMEM_STR_VAL_ROBJ_KEY \
+     (PMEM_STR_VAL | PMEM_STR_ROBJ | PMEM_STR_KEY) /* String: value, robj and key on PMEM */
+#define PMEM_STR_VAL_ROBJ_DICTENTRY \
+     (PMEM_STR_VAL | PMEM_STR_ROBJ | PMEM_STR_DICTENTRY) /* String: value, robj and dictentry on PMEM */
+#define PMEM_STR_VAL_KEY_DICTENTRY \
+     (PMEM_STR_VAL | PMEM_STR_KEY | PMEM_STR_DICTENTRY) /* String: value, key and dictentry on PMEM */
+#define PMEM_STR_ALL \
+     (PMEM_STR_VAL | PMEM_STR_ROBJ | PMEM_STR_KEY | PMEM_STR_DICTENTRY) /* String: value, robj, key and dictentry on PMEM */
+/* PMEM embedded string option */
+#define PMEM_EMBSTR_ROBJVAL (1<<4) /* Embedded string: robj + value on PMEM */
+#define PMEM_EMBSTR_KEY (1<<5) /* Embedded string: key on PMEM */
+#define PMEM_EMBSTR_DICTENTRY (1<<6) /* Embedded string: dictentry on PMEM */
+#define PMEM_EMBSTR_ROBJVAL_KEY \
+     (PMEM_EMBSTR_ROBJVAL | PMEM_EMBSTR_KEY) /* Embedded string: robj + value and key on PMEM */
+#define PMEM_EMBSTR_ROBJVAL_DICTENTRY \
+     (PMEM_EMBSTR_ROBJVAL | PMEM_EMBSTR_DICTENTRY) /* Embedded string: robj + value and dictentry on PMEM */
+#define PMEM_EMBSTR_ALL \
+     (PMEM_EMBSTR_ROBJVAL | PMEM_EMBSTR_KEY | PMEM_EMBSTR_DICTENTRY) /* Embedded string: robj + value, key and dictentry on PMEM */
+
 /* Replication diskless load defines */
 #define REPL_DISKLESS_LOAD_DISABLED 0
 #define REPL_DISKLESS_LOAD_WHEN_DB_EMPTY 1
@@ -1299,6 +1331,8 @@ struct redisServer {
     int lfu_log_factor;             /* LFU logarithmic counter factor. */
     int lfu_decay_time;             /* LFU counter decay factor. */
     long long proto_max_bulk_len;   /* Protocol bulk length maximum size. */
+    /* PMEM */
+    int pmem_str_mode;              /* Persistent Memory policy for string/embedded string. */
     /* Blocked clients */
     unsigned int blocked_clients;   /* # of clients executing a blocking cmd.*/
     unsigned int blocked_clients_by_type[BLOCKED_NUM];


### PR DESCRIPTION
Should be merged after #120 

Details:
- config is handled by pmem-str-mode param in redis.conf
- string and embedded string structures are covered
- scenarios assumed that PMEM placement for value is mandatory

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/121)
<!-- Reviewable:end -->
