### PR TITLE
Add Dockerfile for Fedora 31

### DIFF
--- a/utils/docker/Dockerfile.fedora-31
+++ b/utils/docker/Dockerfile.fedora-31
@@ -1,0 +1,55 @@
+#
+#  Copyright (C) 2020 Intel Corporation.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright notice(s),
+#     this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright notice(s),
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) ``AS IS'' AND ANY EXPRESS
+#  OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO
+#  EVENT SHALL THE COPYRIGHT HOLDER(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+#  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+#  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+#  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Pull base image
+FROM fedora:31
+
+LABEL maintainer="patryk.kaminski@intel.com"
+
+# Update the dnf cache and install basic tools
+RUN dnf update -y && dnf install -y \
+    daxctl-devel \
+    gcc \
+    make \
+    numactl-devel \
+    tcl-devel \
+    which \
+    && dnf clean all
+
+# Add user
+ENV USER redisuser
+ENV USERPASS redispass
+RUN useradd -m $USER -p `mkpasswd $USERPASS`
+
+# Install memkind
+ENV MEMKIND_URL="http://download.opensuse.org/repositories/home:/mbiesek/Fedora_31/x86_64/memkind-1.10.0-2.2.x86_64.rpm"
+ENV MEMKIND_DEVEL_URL="http://download.opensuse.org/repositories/home:/mbiesek/Fedora_31/x86_64/memkind-devel-1.10.0-2.2.x86_64.rpm"
+RUN rpm -i --nosignature $MEMKIND_URL $MEMKIND_DEVEL_URL
+
+WORKDIR /home/$USER/redis
+
+# Allow user to create files in the home directory
+RUN chown -R $USER:$USER /home/$USER
+
+# Change user to $USER
+USER $USER

--- a/utils/docker/docker_run_test.sh
+++ b/utils/docker/docker_run_test.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+#  Copyright (C) 2020 Intel Corporation.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright notice(s),
+#     this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright notice(s),
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) ``AS IS'' AND ANY EXPRESS
+#  OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO
+#  EVENT SHALL THE COPYRIGHT HOLDER(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+#  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+#  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+#  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#
+# docker_run_test.sh - is called inside a Docker container;
+# runs redis tests
+#
+set -e
+
+# build redis
+if [ "$REDIS_ALLOCATOR" == "memkind" ]; then
+    make MALLOC=memkind -j "$(nproc --all)"
+else
+    make -j "$(nproc --all)"
+fi
+
+# run redis tests
+make test

--- a/utils/docker/run_local.sh
+++ b/utils/docker/run_local.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+#
+#  Copyright (C) 2020 Intel Corporation.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright notice(s),
+#     this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright notice(s),
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) ``AS IS'' AND ANY EXPRESS
+#  OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO
+#  EVENT SHALL THE COPYRIGHT HOLDER(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+#  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+#  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+#  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#
+# run_local.sh - builds a container with Docker image
+# and runs docker_run_test.sh script inside it
+#
+# Parameters:
+# -name of the Docker image file
+
+set -e
+
+DOCKER_IMAGE_NAME="Dockerfile.fedora-31"
+
+if [[ -z "$REDIS_HOST_PATH" ]]; then
+    echo "REDIS_HOST_PATH has to be set."
+    exit 1
+fi
+
+# Container path should be the same as WORKDIR in Dockerfile
+REDIS_CONTAINER_PATH=/home/redisuser/redis/
+CONTAINER_NAME=redis-6.0
+
+docker build --tag "$CONTAINER_NAME" \
+             --file "$DOCKER_IMAGE_NAME" \
+             --build-arg http_proxy=$http_proxy \
+             --build-arg https_proxy=$https_proxy \
+             .
+
+docker run --rm \
+           --privileged=true \
+           --tty=true \
+           --env http_proxy=$http_proxy \
+           --env https_proxy=$https_proxy \
+           --env REDIS_CONTAINER_PATH="$REDIS_CONTAINER_PATH" \
+           --env REDIS_ALLOCATOR="$REDIS_ALLOCATOR" \
+           --mount type=bind,source="$REDIS_HOST_PATH",target="$REDIS_CONTAINER_PATH" \
+            "$CONTAINER_NAME" utils/docker/docker_run_test.sh


### PR DESCRIPTION
Add bash scripts and Dockerfile to run tests on Fedora 31 image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/123)
<!-- Reviewable:end -->
