### PR TITLE
Limit occurence of USE_MEMKIND directive

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -503,12 +503,11 @@ robj *tryObjectEncoding(robj *o) {
      * OBJ_ENCODING_EMBSTR_SIZE_LIMIT. */
     trimStringObjectIfNeeded(o);
 
-#ifdef USE_MEMKIND
     if (server.pmem_str_mode & PMEM_STR_VAL) {
         /* Move sds to PM */
         o->ptr = moveSdsToPM(o->ptr);
     }
-#endif
+
     /* Return the original object. */
     return o;
 }

--- a/src/sds.c
+++ b/src/sds.c
@@ -226,6 +226,14 @@ sds moveSdsToPM(sds s) {
     sdsfree(s);
     return new;
 }
+#else
+sds moveSdsToPM(sds s) {
+    (void)s;
+    printf("ERROR: moveSdsToPM is supported only by memkind\n");
+    exit(1);
+     /* unreachable */
+    return NULL;
+}
 #endif
 
 /* Free an sds string. No operation is performed if 's' is NULL. */

--- a/src/sds.h
+++ b/src/sds.h
@@ -226,9 +226,7 @@ sds sdscat(sds s, const char *t);
 sds sdscatsds(sds s, const sds t);
 sds sdscpylen(sds s, const char *t, size_t len);
 sds sdscpy(sds s, const char *t);
-#ifdef USE_MEMKIND
 sds moveSdsToPM(sds s);
-#endif
 sds sdscatvprintf(sds s, const char *fmt, va_list ap);
 #ifdef __GNUC__
 sds sdscatprintf(sds s, const char *fmt, ...)


### PR DESCRIPTION
Lift the limit of PMEM functions in interfaces. Provide non-fatal
implementation only for memkind allocator.
For allocators different than memkind:
First level of check is done by validate configuration (during startup) -
server.pmem_str_mode  must be set to "none" value.
Second level of check - when PMEM methods would be called without
checking server.pmem_str_mode server will exit with proper error message

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/128)
<!-- Reviewable:end -->
