### PR TITLE
Extend redis configuration options

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1702,5 +1702,27 @@ rdb-save-incremental-fsync yes
 # active-defrag-max-scan-fields 1000
 
 ############################### PMEM CONFIG ###############################
+
+# Redis supports four different Memory Allocation Policies:
+#
+# only-dram: use only DRAM - do not use Persistent Memory
+# only-pmem: use only Persistent Memory - do not use DRAM
+# mixed-threshold: use Persistent Memory and DRAM - use threshold described by pmem-threshold
+# mixed-ratio: use Persistent Memory and DRAM - use ratio described by dram-pmem-ratio
+memory-alloc-policy only-dram
+
+# The syntax of dram-pmem-ratio directive is the following:
+#
+# dram-pmem-ratio <dram_value> <pmem_value>
+#
+# Expected proportion of memory placement between DRAM and Persistent Memory.
+# dram_value and pmem_value are values from range 1-INT_MAX
+# In the example below the behaviour will be to:
+# Place 25% of all memory in DRAM and 75% in Persistent Memory
+
+dram-pmem-ratio 1 3
+
 # Persistent memory threshold value
+# The minimum allocation size measured in bytes which goes to Persistent Memory.
+# Any allocation of the size smaller than this threshold goes to DRAM.
 pmem-threshold 64

--- a/src/config.c
+++ b/src/config.c
@@ -91,6 +91,14 @@ configEnum aof_fsync_enum[] = {
     {NULL, 0}
 };
 
+configEnum memory_alloc_policy_enum[] = {
+    {"only-pmem", MEM_POLICY_ONLY_PMEM},
+    {"only-dram", MEM_POLICY_ONLY_DRAM},
+    {"mixed-threshold", MEM_POLICY_MIXED_THRESHOLD},
+    {"mixed-ratio", MEM_POLICY_MIXED_RATIO},
+    {NULL, 0}
+};
+
 configEnum repl_diskless_load_enum[] = {
     {"disabled", REPL_DISKLESS_LOAD_DISABLED},
     {"on-empty-db", REPL_DISKLESS_LOAD_WHEN_DB_EMPTY},
@@ -364,6 +372,14 @@ void loadServerConfigFromString(char *config) {
             } else if (argc == 2 && !strcasecmp(argv[1],"")) {
                 resetServerSaveParams();
             }
+        } else if (!strcasecmp(argv[0],"dram-pmem-ratio") && argc == 3) {
+                int dram = atoi(argv[1]);
+                int pmem = atoi(argv[2]);
+                if (dram == 0 || pmem == 0) {
+                  err = "Invalid dram-pmem-ratio parameters"; goto loaderr;
+                }
+                server.pmem_ratio.dram_val = dram;
+                server.pmem_ratio.pmem_val = pmem;
         } else if (!strcasecmp(argv[0],"dir") && argc == 2) {
             if (chdir(argv[1]) == -1) {
                 serverLog(LL_WARNING,"Can't chdir to '%s': %s",
@@ -703,6 +719,32 @@ void configSetCommand(client *c) {
             server.client_obuf_limits[class].soft_limit_seconds = soft_seconds;
         }
         sdsfreesplitres(v,vlen);
+    } config_set_special_field("dram-pmem-ratio") {
+        int vlen, j;
+        sds *v = sdssplitlen(o->ptr,sdslen(o->ptr)," ",1,&vlen);
+        
+        /* We need value length equal 2: <dram_value> <pmem_value>*/
+        if (vlen != 2) {
+            sdsfreesplitres(v,vlen);
+            goto badfmt;
+        }
+         /* Perform sanity check before setting the new config:
+         * - Pmem >= 1, Dram >= 1 */
+        for (j = 0; j < vlen; j++) {
+            char *eptr;
+            long val;
+
+            val = strtoll(v[j], &eptr, 10);
+            if (eptr[0] != '\0' || val < 1) {
+                sdsfreesplitres(v,vlen);
+                goto badfmt;
+            }
+        }
+        server.pmem_ratio.dram_val = strtoll(v[0],NULL,10);
+        server.pmem_ratio.pmem_val = strtoll(v[1],NULL,10);
+
+        sdsfreesplitres(v,vlen);
+    
     } config_set_special_field("notify-keyspace-events") {
         int flags = keyspaceEventsStringToFlags(o->ptr);
 
@@ -847,6 +889,13 @@ void configGetCommand(client *c) {
         addReplyBulkCString(c,"client-output-buffer-limit");
         addReplyBulkCString(c,buf);
         sdsfree(buf);
+        matches++;
+    }
+    if  (stringmatch(pattern,"dram-pmem-ratio",1)) {
+        char buf[32];
+        snprintf(buf,sizeof(buf),"%d %d", server.pmem_ratio.dram_val, server.pmem_ratio.pmem_val);
+        addReplyBulkCString(c,"dram-pmem-ratio");
+        addReplyBulkCString(c,buf);
         matches++;
     }
     if (stringmatch(pattern,"unixsocketperm",1)) {
@@ -2090,6 +2139,27 @@ static int updateAppendonly(int val, int prev, char **err) {
     return 1;
 }
 
+static int updateMemoryallocpolicy(int val, int prev, char **err) {
+    UNUSED(prev);
+    switch(val) {
+        case MEM_POLICY_ONLY_DRAM:
+            zmalloc_set_threshold(UINT_MAX);
+            break;
+        case MEM_POLICY_ONLY_PMEM:
+            zmalloc_set_threshold(0U);
+            break;
+        case MEM_POLICY_MIXED_THRESHOLD:
+            zmalloc_set_threshold(server.pmem_threshold);
+            break;
+        case MEM_POLICY_MIXED_RATIO:
+            break;
+        default:
+            *err = "Unknown memory allocation policy.";
+            return 0;
+    }
+    return 1;
+}
+
 static int isValidPmemthreshold(long long  val, char **err) {
 #ifndef USE_MEMKIND
     if (val != UINT_MAX) {
@@ -2106,7 +2176,10 @@ static int isValidPmemthreshold(long long  val, char **err) {
 static int updatePmemthreshold(long long val, long long prev, char **err) {
     UNUSED(prev);
     UNUSED(err);
-    zmalloc_set_threshold((size_t)val);
+    if (server.memory_alloc_policy == MEM_POLICY_MIXED_THRESHOLD) {
+        zmalloc_set_threshold((size_t)val);
+    }
+
     return 1;
 }
 
@@ -2212,6 +2285,7 @@ standardConfig configs[] = {
     createEnumConfig("loglevel", NULL, MODIFIABLE_CONFIG, loglevel_enum, server.verbosity, LL_NOTICE, NULL, NULL),
     createEnumConfig("maxmemory-policy", NULL, MODIFIABLE_CONFIG, maxmemory_policy_enum, server.maxmemory_policy, MAXMEMORY_NO_EVICTION, NULL, NULL),
     createEnumConfig("appendfsync", NULL, MODIFIABLE_CONFIG, aof_fsync_enum, server.aof_fsync, AOF_FSYNC_EVERYSEC, NULL, NULL),
+    createEnumConfig("memory-alloc-policy", NULL, MODIFIABLE_CONFIG, memory_alloc_policy_enum, server.memory_alloc_policy, MEM_POLICY_ONLY_DRAM, NULL, updateMemoryallocpolicy),
 
     /* Integer configs */
     createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.dbnum, 16, INTEGER_CONFIG, NULL, NULL),

--- a/src/server.h
+++ b/src/server.h
@@ -466,6 +466,12 @@ typedef long long ustime_t; /* microsecond time type. */
 #define REDISMODULE_AUX_BEFORE_RDB (1<<0)
 #define REDISMODULE_AUX_AFTER_RDB (1<<1)
 
+/* Memory allocation policy states */
+#define MEM_POLICY_ONLY_DRAM 0          /* only use DRAM */
+#define MEM_POLICY_ONLY_PMEM 1          /* only use PMEM */
+#define MEM_POLICY_MIXED_RATIO 2        /* use DRAM and PMEM ratio variant*/
+#define MEM_POLICY_MIXED_THRESHOLD 3    /* use DRAM and PMEM threshold variant*/
+
 struct RedisModule;
 struct RedisModuleIO;
 struct RedisModuleDigest;
@@ -884,6 +890,11 @@ typedef struct clientBufferLimitsConfig {
     time_t soft_limit_seconds;
 } clientBufferLimitsConfig;
 
+typedef struct ratioDramPmemConfig {
+    int pmem_val;
+    int dram_val;
+} ratioDramPmemConfig;
+
 extern clientBufferLimitsConfig clientBufferLimitsDefaults[CLIENT_TYPE_OBUF_COUNT];
 
 /* The redisOp structure defines a Redis Operation, that is an instance of
@@ -1300,7 +1311,9 @@ struct redisServer {
     int lfu_decay_time;             /* LFU counter decay factor. */
     long long proto_max_bulk_len;   /* Protocol bulk length maximum size. */
     /* PMEM */
-    unsigned int pmem_threshold;    /* Persistent Memory threshold. */
+    int memory_alloc_policy;          /* Policy for memory allocation */
+    unsigned int pmem_threshold;      /* Persistent Memory threshold. */
+    ratioDramPmemConfig pmem_ratio;   /* Persistent Memory ratio. */
     /* Blocked clients */
     unsigned int blocked_clients;   /* # of clients executing a blocking cmd.*/
     unsigned int blocked_clients_by_type[BLOCKED_NUM];

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -94,6 +94,7 @@ start_server {tags {"introspection"}} {
             slaveof
             bind
             requirepass
+            dram-pmem-ratio
         }
 
         set configs {}


### PR DESCRIPTION
- pmem_memory_policy is used to described how/if Persistent Memory is
used
- static strategy - pmem-threshold - this is related to const threshold
from which alocation goes to PMEM
- dynamic strategy - dram-pmem-ratio parameter - the threshold will be
automatically adjusted to fullfill expected dram-pmem-ratio
- [ ] TODO add calculation of dram-pmem-ratio - currently this is unused config option with separate field for dram and for pmem

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/140)
<!-- Reviewable:end -->
