### PR TITLE
Modify handling pmem configuration parameter

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1763,35 +1763,67 @@ rdb-save-incremental-fsync yes
 # the main dictionary scan
 # active-defrag-max-scan-fields 1000
 
-############################### PMEM CONFIG ###############################
-
+############################### MEMORY ALLOCATION CONFIGURATION #############################
+#
+# Memory Allocation Policies allow modifying mechanism how heap memory is allocated via zmalloc()
+# function calls. It can target DRAM, Persistent Memory or both. In general, bigger allocations
+# should be stored in Persistent Memory which provides a higher capacity, while smaller and more
+# frequently used should be stored in DRAM.
+# When allocations are to be mixed on both types of memory, this can be defined with:
+#
+# threshold – allocations smaller than the threshold will target DRAM, equal and bigger
+# will target PMEM
+#
+# ratio – the application will be checking DRAM and PMEM utilization ratio and will adopt internal
+# threshold value to reach the defined ratio
+#
 # Redis supports four different Memory Allocation Policies:
 #
 # only-dram: use only DRAM - do not use Persistent Memory
 # only-pmem: use only Persistent Memory - do not use DRAM
-# mixed-threshold: use Persistent Memory and DRAM - use threshold described by pmem-threshold
-# mixed-ratio: use Persistent Memory and DRAM - use ratio described by dram-pmem-ratio
+# threshold: use both Persistent Memory and DRAM - use threshold described by static-threshold
+# ratio: use both Persistent Memory and DRAM - use ratio described by dram-pmem-ratio
+#
+# By default Redis use only-dram configuration.
 memory-alloc-policy only-dram
+
+# --- THRESHOLD policy ---
+#
+# HOW IT WORKS?
+#
+# When Threshold policy is selected, application will check static-threshold parameter.
+# Allocation of the size smaller than this threshold goes to DRAM.
+# Allocation of the size equal or bigger than this threshold goes to Persistent Memory.
+# Parameter can be modified when application is running using CONFIG SET.
+#   Note: for static-threshold value equal 64 and typical SET workload with 1kb Strings values
+#         received DRAM:PMEM ratio is around 1:20
+
+# Minimum allocation size measured in bytes which goes to Persistent Memory
+static-threshold 64
+
+# --- RATIO policy ---
+#
+# HOW IT WORKS?
+#
+# Application allocates part of data in DRAM and part in Persistent Memory based on value
+# of internal dynamic threshold and dram-pmem-ratio. Application frequently compares DRAM
+# and Persistent Memory utilization and modifies value of internal dynamic threshold by
+# increasing or decreasing it to achieve expected dram-pmem-ratio. Internal dynamic threshold
+# have have minimum possible limit defined by dynamic-threshold-min.
 
 # The syntax of dram-pmem-ratio directive is the following:
 #
 # dram-pmem-ratio <dram_value> <pmem_value>
 #
 # Expected proportion of memory placement between DRAM and Persistent Memory.
-# dram_value and pmem_value are values from range 1-INT_MAX
-# In the example below the behaviour will be to:
+# Real DRAM:PMEM ratio depends on workload and its variability.
+# dram_value and pmem_value are values from range <1,INT_MAX>
+# In the example below the behavior will be to:
 # Place 25% of all memory in DRAM and 75% in Persistent Memory
-
 dram-pmem-ratio 1 3
 
-# Persistent memory initialize value of dynamic threshold
-# Initial value of allocation size measured in bytes which goes to Persistent Memory.
-# Any allocation of the size smaller than this threshold goes to DRAM.
-# This value applies only when Memory Allocation Policy is set to mixed-ratio
-init-dynamic-threshold 64
+# Initial value of dynamic threshold
+initial-dynamic-threshold 64
 
-# Persistent memory static threshold value
-# The minimum allocation size measured in bytes which goes to Persistent Memory.
-# Any allocation of the size smaller than this threshold goes to DRAM.
-# This value applies only when Memory Allocation Policy is set to mixed-threshold
-static-threshold 64
+# Minimum value of dynamic threshold
+dynamic-threshold-min 24

--- a/redis.conf
+++ b/redis.conf
@@ -1784,7 +1784,8 @@ memory-alloc-policy only-dram
 
 dram-pmem-ratio 1 3
 
-# Persistent memory threshold value
+# Persistent memory static threshold value
 # The minimum allocation size measured in bytes which goes to Persistent Memory.
 # Any allocation of the size smaller than this threshold goes to DRAM.
-pmem-threshold 64
+# This value applies only when Memory Allocation Policy is set to mixed-threshold
+static-threshold 64

--- a/redis.conf
+++ b/redis.conf
@@ -1784,6 +1784,12 @@ memory-alloc-policy only-dram
 
 dram-pmem-ratio 1 3
 
+# Persistent memory initialize value of dynamic threshold
+# Initial value of allocation size measured in bytes which goes to Persistent Memory.
+# Any allocation of the size smaller than this threshold goes to DRAM.
+# This value applies only when Memory Allocation Policy is set to mixed-ratio
+init-dynamic-threshold 64
+
 # Persistent memory static threshold value
 # The minimum allocation size measured in bytes which goes to Persistent Memory.
 # Any allocation of the size smaller than this threshold goes to DRAM.

--- a/src/config.c
+++ b/src/config.c
@@ -2208,6 +2208,7 @@ standardConfig configs[] = {
 
     /* Unsigned int configs */
     createUIntConfig("maxclients", NULL, MODIFIABLE_CONFIG, 1, UINT_MAX, server.maxclients, 10000, INTEGER_CONFIG, NULL, updateMaxclients),
+    createUIntConfig("init-dynamic-threshold", NULL, IMMUTABLE_CONFIG, 0, UINT_MAX, server.init_dynamic_threshold, 64, INTEGER_CONFIG, NULL, NULL),
     createUIntConfig("static-threshold", NULL, MODIFIABLE_CONFIG, 0, UINT_MAX, server.static_threshold, 64, INTEGER_CONFIG, NULL, updateStaticthreshold),
 
 

--- a/src/config.c
+++ b/src/config.c
@@ -530,6 +530,12 @@ void loadServerConfigFromString(char *config) {
         goto loaderr;
     }
 
+    if (server.pmem_ratio.pmem_val == 0 && server.pmem_ratio.dram_val == 0 &&
+        server.memory_alloc_policy == MEM_POLICY_MIXED_RATIO) {
+        err = "dram-pmem-ratio must be defined for mixed-ratio memory allocation policy";
+        goto loaderr;
+    }
+
     sdsfreesplitres(lines,totlines);
     return;
 

--- a/src/config.c
+++ b/src/config.c
@@ -2058,20 +2058,7 @@ static int updateAppendonly(int val, int prev, char **err) {
     return 1;
 }
 
-static int isValidPmemthreshold(long long  val, char **err) {
-#ifndef USE_MEMKIND
-    if (val != UINT_MAX) {
-        *err = "Persistent memory key on PMEM requires a Redis server compiled with a memkind ";
-        return 0;
-    }
-#else
-    UNUSED(val);
-    UNUSED(err);
-#endif
-    return 1;
-}
-
-static int updatePmemthreshold(long long val, long long prev, char **err) {
+static int updateStaticthreshold(long long val, long long prev, char **err) {
     UNUSED(prev);
     UNUSED(err);
     if (server.memory_alloc_policy == MEM_POLICY_MIXED_THRESHOLD) {
@@ -2221,7 +2208,8 @@ standardConfig configs[] = {
 
     /* Unsigned int configs */
     createUIntConfig("maxclients", NULL, MODIFIABLE_CONFIG, 1, UINT_MAX, server.maxclients, 10000, INTEGER_CONFIG, NULL, updateMaxclients),
-    createUIntConfig("pmem-threshold", NULL, MODIFIABLE_CONFIG, 0, UINT_MAX, server.pmem_threshold, UINT_MAX, INTEGER_CONFIG, isValidPmemthreshold, updatePmemthreshold),
+    createUIntConfig("static-threshold", NULL, MODIFIABLE_CONFIG, 0, UINT_MAX, server.static_threshold, 64, INTEGER_CONFIG, NULL, updateStaticthreshold),
+
 
     /* Unsigned Long configs */
     createULongConfig("active-defrag-max-scan-fields", NULL, MODIFIABLE_CONFIG, 1, LONG_MAX, server.active_defrag_max_scan_fields, 1000, INTEGER_CONFIG, NULL, NULL), /* Default: keys with more than 1000 fields will be processed separately */

--- a/src/pmem.c
+++ b/src/pmem.c
@@ -40,8 +40,10 @@ void pmemThresholdInit(void)
             zmalloc_set_threshold(0U);
             break;
         case MEM_POLICY_MIXED_THRESHOLD:
-        case MEM_POLICY_MIXED_RATIO:
             zmalloc_set_threshold(server.static_threshold);
+            break;
+        case MEM_POLICY_MIXED_RATIO:
+            zmalloc_set_threshold(server.init_dynamic_threshold);
             break;
         default:
             serverAssert(NULL);

--- a/src/pmem.c
+++ b/src/pmem.c
@@ -39,11 +39,11 @@ void pmemThresholdInit(void)
         case MEM_POLICY_ONLY_PMEM:
             zmalloc_set_threshold(0U);
             break;
-        case MEM_POLICY_MIXED_THRESHOLD:
+        case MEM_POLICY_THRESHOLD:
             zmalloc_set_threshold(server.static_threshold);
             break;
-        case MEM_POLICY_MIXED_RATIO:
-            zmalloc_set_threshold(server.init_dynamic_threshold);
+        case MEM_POLICY_RATIO:
+            zmalloc_set_threshold(server.initial_dynamic_threshold);
             break;
         default:
             serverAssert(NULL);

--- a/src/pmem.c
+++ b/src/pmem.c
@@ -41,7 +41,7 @@ void pmemThresholdInit(void)
             break;
         case MEM_POLICY_MIXED_THRESHOLD:
         case MEM_POLICY_MIXED_RATIO:
-            zmalloc_set_threshold(server.pmem_threshold);
+            zmalloc_set_threshold(server.static_threshold);
             break;
         default:
             serverAssert(NULL);

--- a/src/server.h
+++ b/src/server.h
@@ -474,8 +474,8 @@ typedef long long ustime_t; /* microsecond time type. */
 /* Memory allocation policy states */
 #define MEM_POLICY_ONLY_DRAM 0          /* only use DRAM */
 #define MEM_POLICY_ONLY_PMEM 1          /* only use PMEM */
-#define MEM_POLICY_MIXED_RATIO 2        /* use DRAM and PMEM ratio variant*/
-#define MEM_POLICY_MIXED_THRESHOLD 3    /* use DRAM and PMEM threshold variant*/
+#define MEM_POLICY_RATIO     2          /* use DRAM and PMEM - ratio variant*/
+#define MEM_POLICY_THRESHOLD 3          /* use DRAM and PMEM - threshold variant*/
 
 struct RedisModule;
 struct RedisModuleIO;
@@ -1320,10 +1320,11 @@ struct redisServer {
     int lfu_decay_time;             /* LFU counter decay factor. */
     long long proto_max_bulk_len;   /* Protocol bulk length maximum size. */
     /* PMEM */
-    int memory_alloc_policy;          /* Policy for memory allocation */
-    unsigned int static_threshold;    /* Persistent Memory static threshold. */
-    unsigned int init_dynamic_threshold;    /* Persistent Memory initial dynamic threshold. */
-    ratioDramPmemConfig pmem_ratio;   /* Persistent Memory ratio. */
+    int memory_alloc_policy;                  /* Policy for memory allocation */
+    unsigned int static_threshold;            /* Persistent Memory static threshold */
+    unsigned int initial_dynamic_threshold;   /* Persistent Memory initial dynamic threshold */
+    unsigned int dynamic_threshold_min;       /* Minimum value of dynamic threshold */
+    ratioDramPmemConfig dram_pmem_ratio;      /* DRAM/Persistent Memory ratio */
     /* Blocked clients */
     unsigned int blocked_clients;   /* # of clients executing a blocking cmd.*/
     unsigned int blocked_clients_by_type[BLOCKED_NUM];

--- a/src/server.h
+++ b/src/server.h
@@ -1321,7 +1321,7 @@ struct redisServer {
     long long proto_max_bulk_len;   /* Protocol bulk length maximum size. */
     /* PMEM */
     int memory_alloc_policy;          /* Policy for memory allocation */
-    unsigned int pmem_threshold;      /* Persistent Memory threshold. */
+    unsigned int static_threshold;    /* Persistent Memory static threshold. */
     ratioDramPmemConfig pmem_ratio;   /* Persistent Memory ratio. */
     /* Blocked clients */
     unsigned int blocked_clients;   /* # of clients executing a blocking cmd.*/

--- a/src/server.h
+++ b/src/server.h
@@ -1322,6 +1322,7 @@ struct redisServer {
     /* PMEM */
     int memory_alloc_policy;          /* Policy for memory allocation */
     unsigned int static_threshold;    /* Persistent Memory static threshold. */
+    unsigned int init_dynamic_threshold;    /* Persistent Memory initial dynamic threshold. */
     ratioDramPmemConfig pmem_ratio;   /* Persistent Memory ratio. */
     /* Blocked clients */
     unsigned int blocked_clients;   /* # of clients executing a blocking cmd.*/

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -96,6 +96,7 @@ start_server {tags {"introspection"}} {
             requirepass
             dram-pmem-ratio
             memory-alloc-policy
+            init-dynamic-threshold
         }
 
         set configs {}

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -96,7 +96,8 @@ start_server {tags {"introspection"}} {
             requirepass
             dram-pmem-ratio
             memory-alloc-policy
-            init-dynamic-threshold
+            initial-dynamic-threshold
+            dynamic-threshold-min
         }
 
         set configs {}


### PR DESCRIPTION
Add sanity check for Persistent Memory ratio
Change pmem threshold default value to 64
Extend description of parameters
Add separate threshold value for pmem-dram ratio
Synchronize changes with memkeydb

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/156)
<!-- Reviewable:end -->
