### PR TITLE
Add sanity check for dynamic pmem threshold

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -530,10 +530,15 @@ void loadServerConfigFromString(char *config) {
         goto loaderr;
     }
 
-    if (server.dram_pmem_ratio.pmem_val == 0 && server.dram_pmem_ratio.dram_val == 0 &&
-        server.memory_alloc_policy == MEM_POLICY_RATIO) {
-        err = "dram-pmem-ratio must be defined for ratio memory allocation policy";
-        goto loaderr;
+    if (server.memory_alloc_policy == MEM_POLICY_RATIO) {
+        if (server.dynamic_threshold_min > server.initial_dynamic_threshold) {
+            err = "dynamic threshold: initial value must be greater than or equal to minimum value for ratio memory allocation policy";
+            goto loaderr;
+        }
+        if (server.dram_pmem_ratio.pmem_val == 0 && server.dram_pmem_ratio.dram_val == 0) {
+            err = "dram-pmem-ratio must be defined for ratio memory allocation policy";
+            goto loaderr;
+        }
     }
 
     sdsfreesplitres(lines,totlines);


### PR DESCRIPTION
- minimum limit could not be greater than initial value of dynamic
threshold

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/157)
<!-- Reviewable:end -->
