### PR TITLE
Update defrag time-sensitive test for memkind

### DIFF
--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -73,7 +73,12 @@ start_server {tags {"defrag"}} {
                 }
 
                 # Wait for the active defrag to stop working.
-                wait_for_condition 150 100 {
+                if {[string match {*memkind*} [s mem_allocator]]} {
+                    set defrag_stop_time 200
+                } else {
+                    set defrag_stop_time 150
+                }
+                wait_for_condition $defrag_stop_time 100 {
                     [s active_defrag_running] eq 0
                 } else {
                     after 120 ;# serverCron only updates the info once in 100ms
@@ -199,7 +204,12 @@ start_server {tags {"defrag"}} {
                 }
 
                 # wait for the active defrag to stop working
-                wait_for_condition 500 100 {
+                if {[string match {*memkind*} [s mem_allocator]]} {
+                    set defrag_stop_time 900
+                } else {
+                    set defrag_stop_time 500
+                }
+                wait_for_condition $defrag_stop_time 100 {
                     [s active_defrag_running] eq 0
                 } else {
                     after 120 ;# serverCron only updates the info once in 100ms


### PR DESCRIPTION
For memkind defragger could still perform fragmentation, when jemalloc
defragger already finish it.
Active defrag takes for jemalloc 10-11 sec while for memkind 15-18 sec
(in rare cases even 27 sec).
Defrag big keys takes for jemalloc 15-16 sec while for memkind 17-61
sec (in rare cases even 105 sec).
Adjust limits fix the issues with randomly failing test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/165)
<!-- Reviewable:end -->
