### PR TITLE
Modify usable size for memkind

### DIFF
--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -59,7 +59,7 @@
 #define ZMALLOC_LIB "memkind"
 #include <memkind.h>
 #define HAVE_MALLOC_SIZE 1
-#define zmalloc_size(p) memkind_malloc_usable_size(NULL, p)
+#define zmalloc_size(p) memkind_malloc_usable_size(MEMKIND_DEFAULT, p)
 
 #elif defined(__APPLE__)
 #include <malloc/malloc.h>


### PR DESCRIPTION
- memkind_malloc_usable_size for jemalloc implementation doesn't need
passing kind
- with passing MEMKIND_DEFAULT we don't perform unnecessary detect_kind
operatin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/167)
<!-- Reviewable:end -->
