### PR TITLE
Revert "Modify usable size for memkind allocator"

### DIFF
--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -59,7 +59,7 @@
 #define ZMALLOC_LIB "memkind"
 #include <memkind.h>
 #define HAVE_MALLOC_SIZE 1
-#define zmalloc_size(p) memkind_malloc_usable_size(MEMKIND_DEFAULT, p)
+#define zmalloc_size(p) memkind_malloc_usable_size(NULL, p)
 
 #elif defined(__APPLE__)
 #include <malloc/malloc.h>


### PR DESCRIPTION
This reverts commit d367c1c477c8daebb3c100261bba0e1b8dbeaa51.

Functionality is provided on libmemkind layer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/187)
<!-- Reviewable:end -->
