### PR TITLE
[MEMKEYDB] Move frequently used structures explicitly to DRAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ The data stored on the medium is volatile and the persistency is preserved with 
 
 Building MemKeyDB
 --------------
+You will need to install the following required packages on the build system:
+* libdaxctl-devel (v66 or later) -- required by memkind
+* memkind ([v1.10.1-rc2](https://github.com/memkind/memkind/releases/tag/v1.10.1-rc2) or later) - with custom build options described below
+
+To install memkind please call:
+
+    % ./autogen.sh
+    % ARENA_LIMIT=1 MIN_LG_ALIGN=3 ./configure --disable-heap-manager
+    % make
+    % make install
 
 It is as simple as:
 

--- a/src/adlist.c
+++ b/src/adlist.c
@@ -33,16 +33,15 @@
 #include "adlist.h"
 #include "zmalloc.h"
 
-/* Create a new list. The created list can be freed with
- * AlFreeList(), but private value of every node need to be freed
- * by the user before to call AlFreeList().
- *
- * On error, NULL is returned. Otherwise the pointer to the new list. */
-list *listCreate(void)
+#define LIST_GENERAL_VARIANT  0
+#define LIST_DRAM_VARIANT     1
+
+static list *_listCreate(int on_dram)
 {
     struct list *list;
 
-    if ((list = zmalloc(sizeof(*list))) == NULL)
+    list = (on_dram == LIST_DRAM_VARIANT) ? zmalloc_dram(sizeof(*list)) : zmalloc(sizeof(*list));
+    if (list == NULL)
         return NULL;
     list->head = list->tail = NULL;
     list->len = 0;
@@ -52,8 +51,26 @@ list *listCreate(void)
     return list;
 }
 
+/* Create a new list. The created list can be freed with
+ * AlFreeList(), but private value of every node need to be freed
+ * by the user before to call AlFreeList().
+ *
+ * On error, NULL is returned. Otherwise the pointer to the new list. */
+list *listCreate(void) {
+    return _listCreate(LIST_GENERAL_VARIANT);
+}
+
+/* Create a new list on DRAM. The created list can be freed with
+ * AlFreeList(), but private value of every node need to be freed
+ * by the user before to call AlFreeList().
+ *
+ * On error, NULL is returned. Otherwise the pointer to the new list. */
+list *listCreateDRAM(void) {
+    return _listCreate(LIST_DRAM_VARIANT);
+}
+
 /* Remove all the elements from the list without destroying the list itself. */
-void listEmpty(list *list)
+static void _listEmpty(list *list, int on_dram)
 {
     unsigned long len;
     listNode *current, *next;
@@ -63,11 +80,21 @@ void listEmpty(list *list)
     while(len--) {
         next = current->next;
         if (list->free) list->free(current->value);
-        zfree(current);
+        if (on_dram == LIST_DRAM_VARIANT) zfree_dram(current); else zfree(current);
         current = next;
     }
     list->head = list->tail = NULL;
     list->len = 0;
+}
+
+/* Remove all the elements from the list without destroying the list itself. */
+void listEmpty(list *list) {
+    _listEmpty(list, LIST_GENERAL_VARIANT);
+}
+
+/* Remove all the elements from the list on DRAM without destroying the list itself. */
+void listEmptyDRAM(list *list) {
+    _listEmpty(list, LIST_DRAM_VARIANT);
 }
 
 /* Free the whole list.
@@ -79,17 +106,26 @@ void listRelease(list *list)
     zfree(list);
 }
 
+/* Free the whole list from DRAM.
+ *
+ * This function can't fail. */
+void listReleaseDRAM(list *list)
+{
+    listEmpty(list);
+    zfree_dram(list);
+}
+
 /* Add a new node to the list, to head, containing the specified 'value'
  * pointer as value.
  *
  * On error, NULL is returned and no operation is performed (i.e. the
  * list remains unaltered).
  * On success the 'list' pointer you pass to the function is returned. */
-list *listAddNodeHead(list *list, void *value)
+static list *_listAddNodeHead(list *list, void *value, int on_dram)
 {
     listNode *node;
-
-    if ((node = zmalloc(sizeof(*node))) == NULL)
+    node = (on_dram == LIST_DRAM_VARIANT) ? zmalloc_dram(sizeof(*node)) : zmalloc(sizeof(*node));
+    if (node == NULL)
         return NULL;
     node->value = value;
     if (list->len == 0) {
@@ -103,6 +139,28 @@ list *listAddNodeHead(list *list, void *value)
     }
     list->len++;
     return list;
+}
+
+/* Add a new node to the list, to head, containing the specified 'value'
+ * pointer as value.
+ *
+ * On error, NULL is returned and no operation is performed (i.e. the
+ * list remains unaltered).
+ * On success the 'list' pointer you pass to the function is returned. */
+list *listAddNodeHead(list *list, void *value)
+{
+    return _listAddNodeHead(list, value, LIST_GENERAL_VARIANT);
+}
+
+/* Add a new node to the list on DRAM, to head, containing the specified 'value'
+ * pointer as value.
+ *
+ * On error, NULL is returned and no operation is performed (i.e. the
+ * list remains unaltered).
+ * On success the 'list' pointer you pass to the function is returned. */
+list *listAddNodeHeadDRAM(list *list, void *value)
+{
+    return _listAddNodeHead(list, value, LIST_DRAM_VARIANT);
 }
 
 /* Add a new node to the list, to tail, containing the specified 'value'
@@ -160,11 +218,7 @@ list *listInsertNode(list *list, listNode *old_node, void *value, int after) {
     return list;
 }
 
-/* Remove the specified node from the specified list.
- * It's up to the caller to free the private value of the node.
- *
- * This function can't fail. */
-void listDelNode(list *list, listNode *node)
+static void _listDelNode(list *list, listNode *node, int on_dram)
 {
     if (node->prev)
         node->prev->next = node->next;
@@ -175,8 +229,26 @@ void listDelNode(list *list, listNode *node)
     else
         list->tail = node->prev;
     if (list->free) list->free(node->value);
-    zfree(node);
+    if (on_dram == LIST_DRAM_VARIANT) zfree_dram(node); else zfree(node);
     list->len--;
+}
+
+/* Remove the specified node from the specified list.
+ * It's up to the caller to free the private value of the node.
+ *
+ * This function can't fail. */
+void listDelNode(list *list, listNode *node)
+{
+    _listDelNode(list, node, LIST_GENERAL_VARIANT);
+}
+
+/* Remove the specified node from DRAM the specified list.
+ * It's up to the caller to free the private value of the node.
+ *
+ * This function can't fail. */
+void listDelNodeDRAM(list *list, listNode *node)
+{
+    _listDelNode(list, node, LIST_DRAM_VARIANT);
 }
 
 /* Returns a list iterator 'iter'. After the initialization every

--- a/src/adlist.h
+++ b/src/adlist.h
@@ -71,12 +71,17 @@ typedef struct list {
 
 /* Prototypes */
 list *listCreate(void);
+list *listCreateDRAM(void);
 void listRelease(list *list);
+void listReleaseDRAM(list *list);
 void listEmpty(list *list);
+void listEmptyDRAM(list *list);
 list *listAddNodeHead(list *list, void *value);
+list *listAddNodeHeadDRAM(list *list, void *value);
 list *listAddNodeTail(list *list, void *value);
 list *listInsertNode(list *list, listNode *old_node, void *value, int after);
 void listDelNode(list *list, listNode *node);
+void listDelNodeDRAM(list *list, listNode *node);
 listIter *listGetIterator(list *list, int direction);
 listNode *listNext(listIter *iter);
 void listReleaseIterator(listIter *iter);

--- a/src/dict.c
+++ b/src/dict.c
@@ -160,7 +160,7 @@ int dictExpand(dict *d, unsigned long size)
     /* Allocate the new hash table and initialize all pointers to NULL */
     n.size = realsize;
     n.sizemask = realsize-1;
-    n.table = zcalloc(realsize*sizeof(dictEntry*));
+    n.table = zcalloc_dram(realsize*sizeof(dictEntry*));
     n.used = 0;
 
     /* Is this the first initialization? If so it's not really a rehashing
@@ -219,7 +219,7 @@ int dictRehash(dict *d, int n) {
 
     /* Check if we already rehashed the whole table... */
     if (d->ht[0].used == 0) {
-        zfree(d->ht[0].table);
+        zfree_dram(d->ht[0].table);
         d->ht[0] = d->ht[1];
         _dictReset(&d->ht[1]);
         d->rehashidx = -1;
@@ -459,7 +459,7 @@ int _dictClear(dict *d, dictht *ht, void(callback)(void *)) {
         }
     }
     /* Free the table and the allocated cache structure */
-    zfree(ht->table);
+    zfree_dram(ht->table);
     /* Re-initialize the table */
     _dictReset(ht);
     return DICT_OK; /* never fails */
@@ -541,7 +541,7 @@ long long dictFingerprint(dict *d) {
 
 dictIterator *dictGetIterator(dict *d)
 {
-    dictIterator *iter = zmalloc(sizeof(*iter));
+    dictIterator *iter = zmalloc_dram(sizeof(*iter));
 
     iter->d = d;
     iter->table = 0;
@@ -602,7 +602,7 @@ void dictReleaseIterator(dictIterator *iter)
         else
             assert(iter->fingerprint == dictFingerprint(iter->d));
     }
-    zfree(iter);
+    zfree_dram(iter);
 }
 
 /* Return a random entry from the hash table. Useful to

--- a/src/module.c
+++ b/src/module.c
@@ -4671,7 +4671,7 @@ void moduleHandleBlockedClients(void) {
                 !(c->flags & CLIENT_PENDING_WRITE))
             {
                 c->flags |= CLIENT_PENDING_WRITE;
-                listAddNodeHead(server.clients_pending_write,c);
+                listAddNodeHeadDRAM(server.clients_pending_write,c);
             }
         }
 

--- a/src/object.c
+++ b/src/object.c
@@ -36,10 +36,13 @@
 #define strtold(a,b) ((long double)strtod((a),(b)))
 #endif
 
+#define OBJ_MEMORY_GENERAL  0
+#define OBJ_MEMORY_DRAM     1
+
 /* ===================== Creation and parsing of objects ==================== */
 
 robj *createObject(int type, void *ptr) {
-    robj *o = zmalloc(sizeof(*o));
+    robj *o = zmalloc_dram(sizeof(*o));
     o->type = type;
     o->encoding = OBJ_ENCODING_RAW;
     o->ptr = ptr;
@@ -350,7 +353,7 @@ void incrRefCount(robj *o) {
     if (o->refcount != OBJ_SHARED_REFCOUNT) o->refcount++;
 }
 
-void decrRefCount(robj *o) {
+static void _decrRefCount(robj *o, int on_dram) {
     if (o->refcount == 1) {
         switch(o->type) {
         case OBJ_STRING: freeStringObject(o); break;
@@ -362,11 +365,23 @@ void decrRefCount(robj *o) {
         case OBJ_STREAM: freeStreamObject(o); break;
         default: serverPanic("Unknown object type"); break;
         }
-        zfree(o);
+        if (on_dram == OBJ_MEMORY_GENERAL || o->encoding == OBJ_ENCODING_EMBSTR) {
+            zfree(o);
+        } else {
+            zfree_dram(o);
+        }
     } else {
         if (o->refcount <= 0) serverPanic("decrRefCount against refcount <= 0");
         if (o->refcount != OBJ_SHARED_REFCOUNT) o->refcount--;
     }
+}
+
+void decrRefCount(robj *o) {
+    _decrRefCount(o, OBJ_MEMORY_GENERAL);
+}
+
+void decrRefCountDRAM(robj *o) {
+    _decrRefCount(o, OBJ_MEMORY_DRAM);
 }
 
 /* This variant of decrRefCount() gets its argument as void, and is useful

--- a/src/sds.h
+++ b/src/sds.h
@@ -218,6 +218,7 @@ static inline void sdssetalloc(sds s, size_t newlen) {
 sds sdsnewlen(const void *init, size_t initlen);
 sds sdsnew(const char *init);
 sds sdsempty(void);
+sds sdsdramempty(void);
 sds sdsdup(const sds s);
 void sdsfree(sds s);
 sds sdsgrowzero(sds s, size_t len);

--- a/src/sdsalloc.h
+++ b/src/sdsalloc.h
@@ -43,5 +43,6 @@
 #define s_malloc zmalloc
 #define s_realloc zrealloc
 #define s_free zfree
+#define s_dram_malloc zmalloc_dram
 
 #endif

--- a/src/server.h
+++ b/src/server.h
@@ -1717,6 +1717,7 @@ void execCommandPropagateExec(client *c);
 
 /* Redis object implementation */
 void decrRefCount(robj *o);
+void decrRefCountDRAM(robj *o);
 void decrRefCountVoid(void *o);
 void incrRefCount(robj *o);
 robj *makeObjectShared(robj *o);


### PR DESCRIPTION
- structures like e.g. client buffers, iterators should stay
on DRAM because they are frequently allocated and freed

Co-authored-by: michalbiesek <michal.biesek@intel.com>

[EDIT]
Commit message updated
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/191)
<!-- Reviewable:end -->
