### PR TITLE
Modify ziplist resize mechanism

### DIFF
--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -587,7 +587,11 @@ unsigned char *ziplistNew(void) {
 
 /* Resize the ziplist. */
 unsigned char *ziplistResize(unsigned char *zl, unsigned int len) {
-    zl = zrealloc(zl,len);
+    unsigned char* znew = zmalloc(len);
+    size_t old_size = zmalloc_size(zl);
+    (len > old_size) ? memcpy(znew, zl, old_size) : memcpy(znew, zl, len);
+    zfree(zl);
+    zl = znew;
     ZIPLIST_BYTES(zl) = intrev32ifbe(len);
     zl[len-1] = ZIP_END;
     return zl;


### PR DESCRIPTION
- instead of realloc call malloc/memcpy/free sequence
- this allows to move ziplist allocation between DRAM and PMEM

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/195)
<!-- Reviewable:end -->
