### PR TITLE
Add used_pmem_memory_mutex

### DIFF
--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -150,6 +150,7 @@ static size_t pmem_threshold = UINT_MAX;
 static size_t used_memory = 0;
 static size_t used_pmem_memory = 0;
 pthread_mutex_t used_memory_mutex = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t used_pmem_memory_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 static void zmalloc_default_oom(size_t size) {
     fprintf(stderr, "zmalloc: Out of memory trying to allocate %zu bytes\n",


### PR DESCRIPTION
- according to comment in atomic_var.h: "The variable 'var' should also
have a declared mutex with the same name and the "_mutex" postfix"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/200)
<!-- Reviewable:end -->
