### PR TITLE
SdsMakeRoom always in DRAM

### DIFF
--- a/src/sds.h
+++ b/src/sds.h
@@ -255,6 +255,7 @@ sds sdsjoinsds(sds *argv, int argc, const char *sep, size_t seplen);
 
 /* Low level functions exposed to the user API */
 sds sdsMakeRoomFor(sds s, size_t addlen);
+sds sdsDramMakeRoomFor(sds s, size_t addlen);
 void sdsIncrLen(sds s, ssize_t incr);
 sds sdsRemoveFreeSpace(sds s);
 size_t sdsAllocSize(sds s);


### PR DESCRIPTION
Introduces 2 variants for SdsMakeRoom funtion: on DRAM and General
Can be used in networking.c

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/redis/205)
<!-- Reviewable:end -->
