### PR TITLE
Fix segfault in 3.2-nvml version

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4022,8 +4022,8 @@ void initPersistentMemory(void) {
             exit(1);
         }
 		
-		server.pm_rootoid = POBJ_ROOT(server.pm_pool, struct redis_pmem_root);
-		server.pm_reconstruct_required = true;
+        server.pm_rootoid = POBJ_ROOT(server.pm_pool, struct redis_pmem_root);
+        server.pm_reconstruct_required = true;
     } else {
         server.pm_rootoid = POBJ_ROOT(server.pm_pool, struct redis_pmem_root);
         root = pmemobj_direct(server.pm_rootoid.oid);

--- a/src/server.c
+++ b/src/server.c
@@ -4015,14 +4015,15 @@ void initPersistentMemory(void) {
     if (server.pm_pool == NULL) {
         /* Open the existing PMEM pool file. */
         server.pm_pool = pmemobj_open(server.pm_file_path, PM_LAYOUT_NAME);
-        server.pm_rootoid = POBJ_ROOT(server.pm_pool, struct redis_pmem_root);
-	server.pm_reconstruct_required = true;
-
+       
         if (server.pm_pool == NULL) {
             serverLog(LL_WARNING,"Cannot init persistent memory poolset file "
                 "%s size %s", server.pm_file_path, pmfile_hmem);
             exit(1);
         }
+		
+		server.pm_rootoid = POBJ_ROOT(server.pm_pool, struct redis_pmem_root);
+		server.pm_reconstruct_required = true;
     } else {
         server.pm_rootoid = POBJ_ROOT(server.pm_pool, struct redis_pmem_root);
         root = pmemobj_direct(server.pm_rootoid.oid);


### PR DESCRIPTION
Addresses and closes https://github.com/pmem/redis/issues/219 ; if `pmemobj_open` also fails, `POBJ_ROOT(...)` will cause a segfault, so check for NULL first.